### PR TITLE
dataTaskPublisher with progress

### DIFF
--- a/Sandbox/ViewModels/FileCellViewModel.swift
+++ b/Sandbox/ViewModels/FileCellViewModel.swift
@@ -8,24 +8,10 @@ final class FileCellViewModel: ObservableObject, Identifiable {
     @Published public var progress: Int = 0
     @Published public var isDownloaded: Bool = false
     @Published public var isDownloading: Bool = false
-    private var observation: NSKeyValueObservation?
     private var location: URL
+    private var disposables = Set<AnyCancellable>()
     private let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-    
-    private lazy var task: URLSessionDownloadTask = {
-        let session = URLSession.shared
-        let task = session.downloadTask(with: self.file.fileUrl) { (tempLocation, _, _) in
-            debugPrint("file saved to: \(String(describing: tempLocation))")
-            debugPrint("saving to: \(String(describing: self.location))")
-            self.location = tempLocation!
-            DispatchQueue.main.async{
-                self.isDownloaded = true
-                self.isDownloading = false
-            }
-        }
-        return task
-    }()
-    
+
     public init(file: File) {
         self.file = file
         self.location = self.documentsPath.appendingPathComponent(file.fileUrl.lastPathComponent)
@@ -34,12 +20,34 @@ final class FileCellViewModel: ObservableObject, Identifiable {
     
     public func download() {
         self.isDownloading = true
-        self.observation = self.task.progress.observe(\.fractionCompleted) { (progress, _) in
-            DispatchQueue.main.async{
-                self.progress = Int(progress.fractionCompleted * 100)
-            }
-        }
-        self.task.resume()
+        URLSession.shared.dataTaskPublisher(for: self.file.fileUrl)
+        .handleEvents(receiveSubscription: { (subscription) in
+            print("Receive subscription")
+        }, receiveOutput: { output in
+            print("Received output: \(output)")
+        }, receiveCompletion: { _ in
+            print("Receive completion")
+        }, receiveCancel: {
+            print("Receive cancel")
+        }, receiveRequest: { demand in
+            print("Receive request: \(demand)")
+            self.isDownloading = true
+        })
+        .sink(receiveCompletion: { completion in
+                debugPrint(".sink() received the completion", String(describing: completion))
+                DispatchQueue.main.async {
+                    self.isDownloaded = true
+                }
+                switch completion {
+                    case .finished:
+                        break
+                    case .failure(let anError):
+                        print("received error: ", anError)
+                }
+        }, receiveValue: { someValue in
+            debugPrint(".sink() received \(someValue)")
+        })
+        .store(in: &disposables)
     }
     
     public func play() {


### PR DESCRIPTION
### Background

The goal here is to download a file, in the background, while presenting its progress to a cell in a list view. Using `Combine`, I am attempting to use the new `dataTaskPublisher`. The challenge seems to be obtaining the download's *progress* and updating the view.

I came across [this sample](https://github.com/j0nathan-ll0yd/ios-Sandbox/blob/master/Sandbox/Extensions/URLSession.swift#L36) of creating your own `dataTaskPublisherWithProgress` using an `Either` and merging the two streams, but that feels ... dirty. Additionally, it seemed to only update the progress at a few intervals: 0%, 5%, then 100%. 🤔 

Regardless, I would prefer to build an extension that would allow the progress for any network task to be available to the publisher -- like a `handleEvent` for `receiveProgress`.

Depending on how one can extend or override methods in Swift, I would *prefer* the interface to be this:
```
URLSession.shared.dataTaskPublisher(for: self.file.fileUrl)
        .handleEvents(receiveSubscription: { (subscription) in
            print("Receive subscription")
        }, receiveOutput: { output in
            print("Received output: \(output)")
        }, receiveCompletion: { _ in
            print("Receive completion")
        }, receiveCancel: {
            print("Receive cancel")
        }, receiveRequest: { demand in
            print("Receive request: \(demand)")
        }, receiveProgress: { progress in
            print("Received progress: \(progress)")
        })
```
Given that this would override the `handleEvents` method to include an additional argument, I could also settle for a new method, specific for progress handling, like:

```
URLSession.shared.dataTaskPublisher(for: self.file.fileUrl)
        .handleProgress({ progress in
            print("Received progress: \(progress)")
        })
```

### Caveats

I recognize that the current implementation is lacking other things I want, such as: downloading a file *in the background* -- this download will pause if the App goes in to the background. 
