### PR TITLE
feat: add file deletion UI with confirmation dialog

### DIFF
--- a/App/Features/FileListFeature.swift
+++ b/App/Features/FileListFeature.swift
@@ -184,6 +184,10 @@ struct FileListFeature {
         state.playingFile = file
         return .none
 
+      case let .files(.element(id: _, action: .delegate(.deleteFailed(message)))):
+        state.errorMessage = "Delete failed: \(message)"
+        return .none
+
       case .dismissPlayer:
         state.playingFile = nil
         return .none

--- a/App/Views/FileListView.swift
+++ b/App/Views/FileListView.swift
@@ -119,6 +119,31 @@ struct FileCellView: View {
       Spacer()
     }
     .padding(.vertical, 6)
+    .opacity(store.isDeleting ? 0.5 : 1.0)
+    .contextMenu {
+      Button(role: .destructive) {
+        store.send(.deleteButtonTapped)
+      } label: {
+        Label("Delete", systemImage: "trash")
+      }
+    }
+    .confirmationDialog(
+      "Delete File",
+      isPresented: Binding(
+        get: { store.showDeleteConfirmation },
+        set: { _ in store.send(.cancelDelete) }
+      ),
+      titleVisibility: .visible
+    ) {
+      Button("Delete", role: .destructive) {
+        store.send(.confirmDelete)
+      }
+      Button("Cancel", role: .cancel) {
+        store.send(.cancelDelete)
+      }
+    } message: {
+      Text("Are you sure you want to delete \"\(store.file.title ?? store.file.key)\"? This action cannot be undone.")
+    }
     .onAppear {
       store.send(.onAppear)
     }


### PR DESCRIPTION
## Summary
- Add deleteFile endpoint to ServerClient to call DELETE /files/{fileId}
- Add confirmation dialog before file deletion
- Context menu with delete option for each file cell
- Delete from server, local storage, and CoreData in correct order
- Handle deletion errors with user feedback via delegate actions

## Implementation Details
- **ServerClient**: Added deleteFile method with proper error handling and auth checks
- **FileCellFeature**: Added delete confirmation state and actions following TCA patterns
- **FileListView**: Added context menu with delete option and confirmation dialog
- **FileListFeature**: Handle delete failure delegate action and show error messages

## Test Plan
- [x] Build succeeds (requires Xcode GUI to approve macros)
- [ ] Context menu shows delete option when long-pressing file cell
- [ ] Confirmation dialog appears when delete is tapped
- [ ] File is deleted from server, local storage, and CoreData on confirmation
- [ ] Error messages displayed when deletion fails
- [ ] File is removed from list on successful deletion