### PR TITLE
refactor(auth): centralize auth state with AuthState type

### DIFF
--- a/App/Enums/AuthState.swift
+++ b/App/Enums/AuthState.swift
@@ -1,0 +1,31 @@
+/// Combined authentication state representing both login and registration status.
+///
+/// This type provides a single source of truth for the user's authentication state,
+/// determined on app launch by `AuthenticationClient.determineAuthState()`.
+///
+/// ## Registration Status
+/// - `.registered`: User has completed Sign in with Apple at least once (Apple ID identifier stored in keychain)
+/// - `.unregistered`: User has never completed Sign in with Apple with this app
+///
+/// ## Login Status
+/// - `.authenticated`: User has valid credentials (Apple ID authorized + JWT token present)
+/// - `.unauthenticated`: User needs to sign in (no token, revoked credentials, or expired session)
+public struct AuthState: Equatable, Sendable {
+  public let loginStatus: LoginStatus
+  public let registrationStatus: RegistrationStatus
+
+  public init(loginStatus: LoginStatus, registrationStatus: RegistrationStatus) {
+    self.loginStatus = loginStatus
+    self.registrationStatus = registrationStatus
+  }
+
+  /// User is authenticated and can access main app features
+  public var isAuthenticated: Bool {
+    loginStatus == .authenticated
+  }
+
+  /// User has previously registered with Sign in with Apple
+  public var isRegistered: Bool {
+    registrationStatus == .registered
+  }
+}

--- a/App/Enums/LoginStatus.swift
+++ b/App/Enums/LoginStatus.swift
@@ -1,4 +1,4 @@
-public enum LoginStatus: Equatable {
+public enum LoginStatus: Equatable, Sendable {
   case authenticated
   case unauthenticated
 }

--- a/App/Enums/RegistrationStatus.swift
+++ b/App/Enums/RegistrationStatus.swift
@@ -1,4 +1,4 @@
-public enum RegistrationStatus: Equatable {
+public enum RegistrationStatus: Equatable, Sendable {
   case registered
   case unregistered
 }

--- a/App/Models/AppError.swift
+++ b/App/Models/AppError.swift
@@ -153,16 +153,15 @@ extension AppError {
     }
 
     // Check for network-related NSErrors
-    if let nsError = error as? NSError {
-      if nsError.domain == NSURLErrorDomain {
-        switch nsError.code {
-        case NSURLErrorNotConnectedToInternet, NSURLErrorNetworkConnectionLost:
-          return .networkUnavailable
-        case NSURLErrorTimedOut:
-          return .timeout
-        default:
-          break
-        }
+    let nsError = error as NSError
+    if nsError.domain == NSURLErrorDomain {
+      switch nsError.code {
+      case NSURLErrorNotConnectedToInternet, NSURLErrorNetworkConnectionLost:
+        return .networkUnavailable
+      case NSURLErrorTimedOut:
+        return .timeout
+      default:
+        break
       }
     }
 

--- a/OfflineMediaDownloaderTests/DiagnosticFeatureTests.swift
+++ b/OfflineMediaDownloaderTests/DiagnosticFeatureTests.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import Foundation
 import Testing
 import ComposableArchitecture
@@ -117,7 +118,7 @@ struct DiagnosticFeatureTests {
   @MainActor
   @Test("Delete token removes from keychain and list")
   func deleteToken() async throws {
-    var deleteTokenCalled = false
+    let deleteTokenCalled = LockIsolated(false)
     var state = DiagnosticFeature.State()
     state.keychainItems = [
       KeychainItem(name: "Token", displayValue: "test...", itemType: .token),
@@ -127,7 +128,7 @@ struct DiagnosticFeatureTests {
     let store = TestStore(initialState: state) {
       DiagnosticFeature()
     } withDependencies: {
-      $0.keychainClient.deleteJwtToken = { deleteTokenCalled = true }
+      $0.keychainClient.deleteJwtToken = { deleteTokenCalled.setValue(true) }
     }
 
     await store.send(.deleteKeychainItem(IndexSet(integer: 0))) {
@@ -135,13 +136,13 @@ struct DiagnosticFeatureTests {
     }
 
     await store.receive(\.keychainItemDeleted)
-    #expect(deleteTokenCalled == true)
+    #expect(deleteTokenCalled.value == true)
   }
 
   @MainActor
   @Test("Delete user data removes from keychain and list")
   func deleteUserData() async throws {
-    var deleteUserDataCalled = false
+    let deleteUserDataCalled = LockIsolated(false)
     var state = DiagnosticFeature.State()
     state.keychainItems = [
       KeychainItem(name: "UserData", displayValue: "Test User", itemType: .userData)
@@ -150,7 +151,7 @@ struct DiagnosticFeatureTests {
     let store = TestStore(initialState: state) {
       DiagnosticFeature()
     } withDependencies: {
-      $0.keychainClient.deleteUserData = { deleteUserDataCalled = true }
+      $0.keychainClient.deleteUserData = { deleteUserDataCalled.setValue(true) }
     }
 
     await store.send(.deleteKeychainItem(IndexSet(integer: 0))) {
@@ -158,13 +159,13 @@ struct DiagnosticFeatureTests {
     }
 
     await store.receive(\.keychainItemDeleted)
-    #expect(deleteUserDataCalled == true)
+    #expect(deleteUserDataCalled.value == true)
   }
 
   @MainActor
   @Test("Delete device data removes from keychain and list")
   func deleteDeviceData() async throws {
-    var deleteDeviceDataCalled = false
+    let deleteDeviceDataCalled = LockIsolated(false)
     var state = DiagnosticFeature.State()
     state.keychainItems = [
       KeychainItem(name: "DeviceData", displayValue: "arn:aws:sns:test", itemType: .deviceData)
@@ -173,7 +174,7 @@ struct DiagnosticFeatureTests {
     let store = TestStore(initialState: state) {
       DiagnosticFeature()
     } withDependencies: {
-      $0.keychainClient.deleteDeviceData = { deleteDeviceDataCalled = true }
+      $0.keychainClient.deleteDeviceData = { deleteDeviceDataCalled.setValue(true) }
     }
 
     await store.send(.deleteKeychainItem(IndexSet(integer: 0))) {
@@ -181,7 +182,7 @@ struct DiagnosticFeatureTests {
     }
 
     await store.receive(\.keychainItemDeleted)
-    #expect(deleteDeviceDataCalled == true)
+    #expect(deleteDeviceDataCalled.value == true)
   }
 
   @MainActor
@@ -205,18 +206,18 @@ struct DiagnosticFeatureTests {
   @MainActor
   @Test("Truncate files calls coreDataClient")
   func truncateFiles() async throws {
-    var truncateCalled = false
+    let truncateCalled = LockIsolated(false)
 
     let store = TestStore(initialState: DiagnosticFeature.State()) {
       DiagnosticFeature()
     } withDependencies: {
-      $0.coreDataClient.truncateFiles = { truncateCalled = true }
+      $0.coreDataClient.truncateFiles = { truncateCalled.setValue(true) }
     }
 
     await store.send(.truncateFilesButtonTapped)
     await store.receive(\.filesTruncated)
 
-    #expect(truncateCalled == true)
+    #expect(truncateCalled.value == true)
   }
 
   // MARK: - Error Handling Tests

--- a/OfflineMediaDownloaderTests/FileListFeatureTests.swift
+++ b/OfflineMediaDownloaderTests/FileListFeatureTests.swift
@@ -398,7 +398,7 @@ struct FileListFeatureTests {
   @Test("Update file URL updates existing file state")
   func updateFileUrl() async throws {
     var state = FileListFeature.State()
-    var pendingFile = TestData.pendingFile
+    let pendingFile = TestData.pendingFile
     state.files = [FileCellFeature.State(file: pendingFile)]
 
     let newUrl = URL(string: "https://example.com/new-url.mp4")!


### PR DESCRIPTION
## Summary

- **Centralize auth state determination**: Added new `AuthState` struct that combines `LoginStatus` and `RegistrationStatus` into a single type, providing a single source of truth for authentication state on app launch
- **Simplify launch flow**: Replaced separate `loginStatusResponse` + `setRegistrationStatus` actions with a single `authStateResponse` action in RootFeature
- **Fix Valet error handling**: KeychainClient now properly detects Valet's `KeychainError.itemNotFound` instead of checking for NSError code -25300, eliminating spurious warning logs

## Changes

### New Files
- `App/Enums/AuthState.swift` - Combined auth state type with documentation

### Modified Files
- `App/Dependencies/AuthenticationClient.swift` - Added `determineAuthState()` method
- `App/Dependencies/KeychainClient.swift` - Fixed error detection for item-not-found cases
- `App/Enums/LoginStatus.swift` - Added `Sendable` conformance
- `App/Enums/RegistrationStatus.swift` - Added `Sendable` conformance
- `App/Models/AppError.swift` - Fixed conditional cast warning
- `App/Views/RootView.swift` - Simplified launch flow
- Test files updated for new auth flow and concurrency warnings fixed

## Test plan

- [x] All unit tests pass
- [x] Build succeeds with no errors
- [ ] Manual test: Fresh install shows unregistered state
- [ ] Manual test: Previously registered user shows registered state on login screen
- [ ] Manual test: Authenticated user goes directly to main view