### PR TITLE
feat: Improve unauthenticated user experience and error debugging

### DIFF
--- a/App/Features/FileListFeature.swift
+++ b/App/Features/FileListFeature.swift
@@ -39,6 +39,7 @@ struct FileListFeature {
     case fileAddedFromPush(File)
     case updateFileUrl(fileId: String, url: URL)
     case refreshFileState(String)  // fileId
+    case clearAllFiles  // Clears state and CoreData (used on registration)
     case delegate(Delegate)
 
     @CasePathable
@@ -88,6 +89,14 @@ struct FileListFeature {
         })
         state.isLoading = false
         return .none
+
+      case .clearAllFiles:
+        // Clear in-memory state and CoreData/downloaded files
+        state.files = []
+        state.pendingFileIds = []
+        return .run { _ in
+          try await coreDataClient.truncateFiles()
+        }
 
       case .refreshButtonTapped:
         state.isLoading = true

--- a/App/Features/MainFeature.swift
+++ b/App/Features/MainFeature.swift
@@ -59,7 +59,13 @@ struct MainFeature {
 
       case .loginSheet(.presented(.delegate(.registrationCompleted))):
         state.loginSheet = nil
-        return .send(.delegate(.registrationCompleted))
+        // Clear default files (including CoreData) and switch to Files tab, then refresh
+        state.selectedTab = .files
+        return .concatenate(
+          .send(.delegate(.registrationCompleted)),
+          .send(.fileList(.clearAllFiles)),
+          .send(.fileList(.refreshButtonTapped))
+        )
 
       case .loginSheet:
         return .none

--- a/App/Views/RootView.swift
+++ b/App/Views/RootView.swift
@@ -149,7 +149,8 @@ struct RootFeature {
 
       case let .deviceRegistrationResponse(.failure(error)):
         // Check if this is an auth error - user can continue browsing as guest
-        if let serverError = error as? ServerClientError, serverError == .unauthorized {
+        if let serverError = error as? ServerClientError,
+           case .unauthorized = serverError {
           state.isAuthenticated = false
           state.main.isAuthenticated = false
           state.main.fileList.isAuthenticated = false

--- a/OfflineMediaDownloaderTests/RootFeatureTests.swift
+++ b/OfflineMediaDownloaderTests/RootFeatureTests.swift
@@ -135,7 +135,7 @@ struct RootFeatureTests {
     let store = TestStore(initialState: state) {
       RootFeature()
     } withDependencies: {
-      $0.serverClient.registerDevice = { _ in throw ServerClientError.unauthorized }
+      $0.serverClient.registerDevice = { _ in throw ServerClientError.unauthorized(requestId: "test-request-id") }
       $0.keychainClient.deleteJwtToken = { }
     }
 


### PR DESCRIPTION
## Summary

- **Auto-fetch files for unauthenticated users**: When an unauthenticated user launches the app, files are automatically fetched from the server so they see default content immediately instead of an empty list
- **Display request ID in error alerts**: All server errors now display the AWS `x-amzn-requestid` header in the alert message, enabling developers to trace issues in server logs
- **Clear files on registration**: When a user registers, default files are purged from both memory and CoreData, and the user is redirected to the Files tab with a fresh file list

## Changes

### Auto-fetch for unauthenticated users (`FileListFeature.swift`)
- `onAppear` now triggers `refreshButtonTapped` for unauthenticated users after loading cached files

### Request ID propagation
- `ServerClientError` cases now include `requestId: String?` parameter
- `AppError.serverError` and `AppError.unauthorized` include `requestId`
- Extract `requestId` from response headers for `undocumented` status codes (e.g., 502)
- Handle `ClientError` from OpenAPI runtime when body decoding fails
- Error alert messages display: `"Error message\n\nRequest ID: abc123"`

### Registration flow (`MainFeature.swift`)
- Added `clearAllFiles` action to `FileListFeature` that clears state and calls `coreDataClient.truncateFiles()`
- On registration completion: dismiss sheet → switch to Files tab → clear files → refresh

## Test plan
- [x] All existing tests pass (updated tests to use new `requestId` parameter)
- [x] Launch app as unauthenticated user - verify files load automatically
- [x] Trigger a server error - verify request ID is displayed in alert
- [x] Register a new account - verify default files are cleared and Files tab is shown