### PR TITLE
feat: Add iOS Share Extension for YouTube URL sharing to Feedly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: macos-14
-    timeout-minutes: 30
+    timeout-minutes: 35
 
     steps:
       - name: Checkout

--- a/App/Dependencies/KeychainClient.swift
+++ b/App/Dependencies/KeychainClient.swift
@@ -7,12 +7,18 @@ class ValetUtil {
   var secureEnclave: SecureEnclaveValet?
   var keychain: Valet
 
-  // Use a safe identifier that works in both app and test environments
-  static let identifier: String = {
+  // App Group identifier for sharing keychain between app and extensions
+  // Team ID: P328YB6M54
+  static let sharedGroupIdentifier = SharedGroupIdentifier(
+    appIDPrefix: "P328YB6M54",
+    nonEmptyGroup: "group.lifegames.OfflineMediaDownloader"
+  )!
+
+  // Legacy identifier for migration purposes (kept for reference)
+  static let legacyIdentifier: String = {
     if let bundleId = Bundle.main.bundleIdentifier, !bundleId.isEmpty {
       return "\(bundleId).Valet"
     }
-    // Fallback for test environments where bundleIdentifier may not be available
     return "com.test.OfflineMediaDownloader.Valet"
   }()
 
@@ -22,16 +28,16 @@ class ValetUtil {
     #if targetEnvironment(simulator)
     secureEnclave = nil
     #else
-    // Try to create SecureEnclaveValet, but it may fail on older devices
-    // or in certain CI environments
-    secureEnclave = SecureEnclaveValet.valet(
-      with: Identifier(nonEmpty: ValetUtil.identifier)!,
+    // Try to create SecureEnclaveValet with shared group for extension access
+    secureEnclave = SecureEnclaveValet.sharedGroupValet(
+      with: ValetUtil.sharedGroupIdentifier,
       accessControl: .userPresence
     )
     #endif
 
-    keychain = Valet.valet(
-      with: Identifier(nonEmpty: ValetUtil.identifier)!,
+    // Use shared group valet so Share Extension can access the keychain
+    keychain = Valet.sharedGroupValet(
+      with: ValetUtil.sharedGroupIdentifier,
       accessibility: .whenUnlocked
     )
   }

--- a/OfflineMediaDownloader.xcodeproj/project.pbxproj
+++ b/OfflineMediaDownloader.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		C44108292F1487B2007EAB48 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C44108282F1487B2007EAB48 /* SwiftUI.framework */; };
 		C44108382F1487B3007EAB48 /* DownloadActivityWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = C44108252F1487B2007EAB48 /* DownloadActivityWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		C44112772F25D658007EAB48 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = C41DD9612F1A5A5A00F041C6 /* SnapshotTesting */; };
+		SHARE00000000000000001 /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = SHARE00000000000000002 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		SHARE00000000000000003 /* Valet in Frameworks */ = {isa = PBXBuildFile; productRef = SHARE00000000000000004 /* Valet */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,6 +41,13 @@
 			remoteGlobalIDString = C44108242F1487B2007EAB48;
 			remoteInfo = DownloadActivityWidgetExtension;
 		};
+		SHARE00000000000000005 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C41DD87C2CC6C52600F041C6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = SHARE00000000000000006;
+			remoteInfo = ShareExtension;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -49,6 +58,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				C44108382F1487B3007EAB48 /* DownloadActivityWidgetExtension.appex in Embed Foundation Extensions */,
+				SHARE00000000000000001 /* ShareExtension.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -65,6 +75,7 @@
 		C44108262F1487B2007EAB48 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		C44108282F1487B2007EAB48 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		C44108412F148878007EAB48 /* DownloadActivityWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DownloadActivityWidgetExtension.entitlements; sourceTree = "<group>"; };
+		SHARE00000000000000002 /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -81,6 +92,13 @@
 				Info.plist,
 			);
 			target = C44108242F1487B2007EAB48 /* DownloadActivityWidgetExtension */;
+		};
+		SHARE00000000000000007 /* Exceptions for "ShareExtension" folder in "ShareExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = SHARE00000000000000006 /* ShareExtension */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -109,6 +127,14 @@
 				C441083C2F1487B3007EAB48 /* Exceptions for "DownloadActivityWidget" folder in "DownloadActivityWidgetExtension" target */,
 			);
 			path = DownloadActivityWidget;
+			sourceTree = "<group>";
+		};
+		SHARE00000000000000008 /* ShareExtension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				SHARE00000000000000007 /* Exceptions for "ShareExtension" folder in "ShareExtension" target */,
+			);
+			path = ShareExtension;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -148,6 +174,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		SHARE00000000000000009 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				SHARE00000000000000003 /* Valet in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -158,6 +192,7 @@
 				C41DD92F2CC972F900F041C6 /* Development.xcconfig */,
 				C41DD8BD2CC6C6F500F041C6 /* Constants.swift */,
 				C41DD8862CC6C52600F041C6 /* App */,
+				SHARE00000000000000008 /* ShareExtension */,
 				C41DD89C2CC6C52700F041C6 /* OfflineMediaDownloaderTests */,
 				C41DD8A62CC6C52700F041C6 /* OfflineMediaDownloaderUITests */,
 				C441082A2F1487B2007EAB48 /* DownloadActivityWidget */,
@@ -175,6 +210,7 @@
 				C41DD8992CC6C52700F041C6 /* OfflineMediaDownloaderTests.xctest */,
 				C41DD8A32CC6C52700F041C6 /* OfflineMediaDownloaderUITests.xctest */,
 				C44108252F1487B2007EAB48 /* DownloadActivityWidgetExtension.appex */,
+				SHARE00000000000000002 /* ShareExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -204,6 +240,7 @@
 			);
 			dependencies = (
 				C44108372F1487B3007EAB48 /* PBXTargetDependency */,
+				SHARE0000000000000000D /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				C41DD8862CC6C52600F041C6 /* App */,
@@ -287,6 +324,29 @@
 			productReference = C44108252F1487B2007EAB48 /* DownloadActivityWidgetExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		SHARE00000000000000006 /* ShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = SHARE0000000000000000A /* Build configuration list for PBXNativeTarget "ShareExtension" */;
+			buildPhases = (
+				SHARE0000000000000000B /* Sources */,
+				SHARE00000000000000009 /* Frameworks */,
+				SHARE0000000000000000C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				SHARE00000000000000008 /* ShareExtension */,
+			);
+			name = ShareExtension;
+			packageProductDependencies = (
+				SHARE00000000000000004 /* Valet */,
+			);
+			productName = ShareExtension;
+			productReference = SHARE00000000000000002 /* ShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -310,6 +370,9 @@
 					};
 					C44108242F1487B2007EAB48 = {
 						CreatedOnToolsVersion = 26.2;
+					};
+					SHARE00000000000000006 = {
+						CreatedOnToolsVersion = 16.0;
 					};
 				};
 			};
@@ -337,6 +400,7 @@
 				C41DD8982CC6C52700F041C6 /* OfflineMediaDownloaderTests */,
 				C41DD8A22CC6C52700F041C6 /* OfflineMediaDownloaderUITests */,
 				C44108242F1487B2007EAB48 /* DownloadActivityWidgetExtension */,
+				SHARE00000000000000006 /* ShareExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -364,6 +428,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		C44108232F1487B2007EAB48 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SHARE0000000000000000C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -402,6 +473,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		SHARE0000000000000000B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -419,6 +497,11 @@
 			isa = PBXTargetDependency;
 			target = C44108242F1487B2007EAB48 /* DownloadActivityWidgetExtension */;
 			targetProxy = C44108362F1487B3007EAB48 /* PBXContainerItemProxy */;
+		};
+		SHARE0000000000000000D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = SHARE00000000000000006 /* ShareExtension */;
+			targetProxy = SHARE00000000000000005 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -758,6 +841,62 @@
 			};
 			name = Release;
 		};
+		SHARE0000000000000000F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C41DD92F2CC972F900F041C6 /* Development.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = P328YB6M54;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Save to Downloader";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = lifegames.OfflineMediaDownloader.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		SHARE00000000000000010 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C41DD92F2CC972F900F041C6 /* Development.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = P328YB6M54;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Save to Downloader";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = lifegames.OfflineMediaDownloader.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -802,6 +941,15 @@
 			buildConfigurations = (
 				C441083A2F1487B3007EAB48 /* Debug */,
 				C441083B2F1487B3007EAB48 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		SHARE0000000000000000A /* Build configuration list for PBXNativeTarget "ShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				SHARE0000000000000000F /* Debug */,
+				SHARE00000000000000010 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -861,6 +1009,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C41DD9602F1A5A5A00F041C6 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
 			productName = SnapshotTesting;
+		};
+		SHARE00000000000000004 /* Valet */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C41DD9222CC81B8100F041C6 /* XCRemoteSwiftPackageReference "Valet" */;
+			productName = Valet;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/OfflineMediaDownloaderTests/TestStoreHelpers.swift
+++ b/OfflineMediaDownloaderTests/TestStoreHelpers.swift
@@ -1,0 +1,335 @@
+import Foundation
+import Testing
+import ComposableArchitecture
+@testable import OfflineMediaDownloader
+
+// MARK: - Common Dependency Presets
+
+/// Extension to configure common test dependencies
+extension DependencyValues {
+  /// Configures a silent logger that does nothing
+  mutating func configureSilentLogger() {
+    self.logger.log = { _, _, _, _, _, _ in }
+  }
+
+  /// Configures keychain with no stored values
+  mutating func configureEmptyKeychain() {
+    self.keychainClient.getJwtToken = { nil }
+    self.keychainClient.getUserIdentifier = { nil }
+    self.keychainClient.getDeviceData = { nil }
+    self.keychainClient.getTokenExpiresAt = { nil }
+  }
+
+  /// Configures keychain with a valid authenticated user
+  mutating func configureAuthenticatedKeychain(token: String = TestData.validJwtToken) {
+    self.keychainClient.getJwtToken = { token }
+    self.keychainClient.setJwtToken = { _ in }
+    self.keychainClient.deleteJwtToken = { }
+    self.keychainClient.getUserIdentifier = { TestData.sampleUser.identifier }
+    self.keychainClient.getUserData = { TestData.sampleUser }
+    self.keychainClient.setUserData = { _ in }
+    self.keychainClient.getTokenExpiresAt = { nil }
+    self.keychainClient.setTokenExpiresAt = { _ in }
+    self.keychainClient.deleteTokenExpiresAt = { }
+  }
+
+  /// Configures file client that reports no files exist
+  mutating func configureEmptyFileSystem() {
+    self.fileClient.fileExists = { _ in false }
+    self.fileClient.deleteFile = { _ in }
+  }
+
+  /// Configures file client that reports all files exist
+  mutating func configureAllFilesExist() {
+    self.fileClient.fileExists = { _ in true }
+    self.fileClient.deleteFile = { _ in }
+  }
+
+  /// Configures CoreData client with empty data
+  mutating func configureEmptyCoreData() {
+    self.coreDataClient.getFiles = { [] }
+    self.coreDataClient.cacheFiles = { _ in }
+    self.coreDataClient.cacheFile = { _ in }
+    self.coreDataClient.deleteFile = { _ in }
+  }
+
+  /// Configures CoreData client with sample files
+  mutating func configureCoreDataWithFiles(_ files: [File] = TestData.multipleFiles) {
+    self.coreDataClient.getFiles = { files }
+    self.coreDataClient.cacheFiles = { _ in }
+    self.coreDataClient.cacheFile = { _ in }
+    self.coreDataClient.deleteFile = { _ in }
+    self.coreDataClient.incrementPlayCount = { }
+  }
+
+  /// Configures server client for successful file fetch
+  mutating func configureSuccessfulFileServer() {
+    self.serverClient.getFiles = { _ in TestData.validFileResponse }
+    self.serverClient.addFile = { _ in TestData.validAddFileResponse }
+  }
+
+  /// Configures thumbnail cache client with no-op operations
+  mutating func configureThumbnailCache() {
+    self.thumbnailCacheClient.deleteThumbnail = { _ in }
+    self.thumbnailCacheClient.getThumbnail = { _, _ in nil }
+    self.thumbnailCacheClient.hasCachedThumbnail = { _ in false }
+    self.thumbnailCacheClient.clearCache = { }
+  }
+
+  /// Applies all common test configurations at once
+  mutating func configureForTesting() {
+    configureSilentLogger()
+    configureEmptyKeychain()
+    configureEmptyFileSystem()
+    configureEmptyCoreData()
+    configureThumbnailCache()
+  }
+}
+
+// MARK: - TestStore Builder Helpers
+
+/// Namespace for test store creation helpers
+enum TestStoreFactory {
+
+  // MARK: - FileListFeature Stores
+
+  /// Creates a FileListFeature store with authenticated user state
+  @MainActor
+  static func authenticatedFileList(
+    files: [File] = [],
+    configure: ((inout DependencyValues) -> Void)? = nil
+  ) -> TestStoreOf<FileListFeature> {
+    var state = FileListFeature.State()
+    state.isAuthenticated = true
+    state.isRegistered = true
+    state.files = IdentifiedArray(uniqueElements: files.map { FileCellFeature.State(file: $0) })
+
+    return TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.configureForTesting()
+      $0.configureCoreDataWithFiles(files.isEmpty ? TestData.multipleFiles : files)
+      $0.configureSuccessfulFileServer()
+      configure?(&$0)
+    }
+  }
+
+  /// Creates a FileListFeature store for unauthenticated user
+  @MainActor
+  static func unauthenticatedFileList(
+    configure: ((inout DependencyValues) -> Void)? = nil
+  ) -> TestStoreOf<FileListFeature> {
+    let state = FileListFeature.State()
+
+    return TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.configureForTesting()
+      configure?(&$0)
+    }
+  }
+
+  // MARK: - RootFeature Stores
+
+  /// Creates a RootFeature store for authenticated user
+  @MainActor
+  static func authenticatedRoot(
+    configure: ((inout DependencyValues) -> Void)? = nil
+  ) -> TestStoreOf<RootFeature> {
+    var state = RootFeature.State()
+    state.isAuthenticated = true
+    state.main = MainFeature.State()
+    state.main.isAuthenticated = true
+    state.main.fileList.isAuthenticated = true
+
+    return TestStore(initialState: state) {
+      RootFeature()
+    } withDependencies: {
+      $0.configureForTesting()
+      $0.configureAuthenticatedKeychain()
+      configure?(&$0)
+    }
+  }
+
+  /// Creates a RootFeature store for unauthenticated user
+  @MainActor
+  static func unauthenticatedRoot(
+    configure: ((inout DependencyValues) -> Void)? = nil
+  ) -> TestStoreOf<RootFeature> {
+    return TestStore(initialState: RootFeature.State()) {
+      RootFeature()
+    } withDependencies: {
+      $0.configureForTesting()
+      configure?(&$0)
+    }
+  }
+
+  // MARK: - MainFeature Stores
+
+  /// Creates a MainFeature store with default state
+  @MainActor
+  static func mainFeature(
+    isAuthenticated: Bool = false,
+    configure: ((inout DependencyValues) -> Void)? = nil
+  ) -> TestStoreOf<MainFeature> {
+    var state = MainFeature.State()
+    state.isAuthenticated = isAuthenticated
+    state.fileList.isAuthenticated = isAuthenticated
+
+    return TestStore(initialState: state) {
+      MainFeature()
+    } withDependencies: {
+      $0.configureForTesting()
+      if isAuthenticated {
+        $0.configureAuthenticatedKeychain()
+      }
+      configure?(&$0)
+    }
+  }
+
+  // MARK: - LoginFeature Stores
+
+  /// Creates a LoginFeature store with default state
+  @MainActor
+  static func loginFeature(
+    configure: ((inout DependencyValues) -> Void)? = nil
+  ) -> TestStoreOf<LoginFeature> {
+    return TestStore(initialState: LoginFeature.State()) {
+      LoginFeature()
+    } withDependencies: {
+      $0.configureForTesting()
+      configure?(&$0)
+    }
+  }
+
+  // MARK: - FileCellFeature Stores
+
+  /// Creates a FileCellFeature store with a sample file
+  @MainActor
+  static func fileCell(
+    file: File = TestData.sampleFile,
+    isDownloaded: Bool = false,
+    configure: ((inout DependencyValues) -> Void)? = nil
+  ) -> TestStoreOf<FileCellFeature> {
+    var state = FileCellFeature.State(file: file)
+    state.isDownloaded = isDownloaded
+
+    return TestStore(initialState: state) {
+      FileCellFeature()
+    } withDependencies: {
+      $0.configureForTesting()
+      configure?(&$0)
+    }
+  }
+
+  // MARK: - ActiveDownloadsFeature Stores
+
+  /// Creates an ActiveDownloadsFeature store with optional active downloads
+  @MainActor
+  static func activeDownloads(
+    downloads: [ActiveDownloadsFeature.ActiveDownload] = [],
+    configure: ((inout DependencyValues) -> Void)? = nil
+  ) -> TestStoreOf<ActiveDownloadsFeature> {
+    var state = ActiveDownloadsFeature.State()
+    state.activeDownloads = IdentifiedArray(uniqueElements: downloads)
+
+    return TestStore(initialState: state) {
+      ActiveDownloadsFeature()
+    } withDependencies: {
+      $0.configureForTesting()
+      configure?(&$0)
+    }
+  }
+}
+
+// MARK: - Test Timing Utilities
+
+/// Timing trait for tests that may take longer (under 1 minute)
+/// Use for integration-style tests or tests with multiple async steps
+let standardTest = Testing.TimeLimitTrait.timeLimit(.minutes(1))
+
+/// Timing trait for slower tests (under 2 minutes)
+/// Use for tests that involve significant setup or many assertions
+let slowTest = Testing.TimeLimitTrait.timeLimit(.minutes(2))
+
+// MARK: - Test Measurement Helpers
+
+/// Measures execution time of a test block and logs it
+/// Useful for identifying slow tests during development
+@MainActor
+func measureTest(
+  _ label: String,
+  threshold: Duration = .seconds(1),
+  operation: () async throws -> Void
+) async throws {
+  let clock = ContinuousClock()
+  let start = clock.now
+  try await operation()
+  let elapsed = clock.now - start
+
+  if elapsed > threshold {
+    // Log slow tests for identification
+    print("⚠️ SLOW TEST: \(label) took \(elapsed)")
+  }
+}
+
+// MARK: - Common Test State Builders
+
+/// Helpers for building common test states
+enum TestStates {
+
+  /// Creates an authenticated MainFeature state
+  static func authenticatedMain() -> MainFeature.State {
+    var state = MainFeature.State()
+    state.isAuthenticated = true
+    state.isRegistered = true
+    state.fileList.isAuthenticated = true
+    state.fileList.isRegistered = true
+    return state
+  }
+
+  /// Creates a FileListFeature state with sample files
+  static func fileListWithFiles(_ files: [File] = TestData.multipleFiles) -> FileListFeature.State {
+    var state = FileListFeature.State()
+    state.isAuthenticated = true
+    state.isRegistered = true
+    state.files = IdentifiedArray(uniqueElements: files.map { FileCellFeature.State(file: $0) })
+    return state
+  }
+
+  /// Creates a FileCellFeature state for a downloaded file
+  static func downloadedFileCell(file: File = TestData.downloadedFile) -> FileCellFeature.State {
+    var state = FileCellFeature.State(file: file)
+    state.isDownloaded = true
+    state.downloadProgress = 1.0
+    return state
+  }
+
+  /// Creates a FileCellFeature state for a downloading file
+  static func downloadingFileCell(
+    file: File = TestData.sampleFile,
+    progress: Double = 0.5
+  ) -> FileCellFeature.State {
+    var state = FileCellFeature.State(file: file)
+    state.isDownloading = true
+    state.downloadProgress = progress
+    return state
+  }
+
+  /// Creates an ActiveDownload item for testing
+  static func activeDownload(
+    fileId: String = "test-file",
+    title: String = "Test Video.mp4",
+    progress: Int = 50,
+    status: ActiveDownloadsFeature.ActiveDownload.DownloadStatus = .downloading,
+    isBackgroundInitiated: Bool = false
+  ) -> ActiveDownloadsFeature.ActiveDownload {
+    ActiveDownloadsFeature.ActiveDownload(
+      fileId: fileId,
+      title: title,
+      progress: progress,
+      status: status,
+      isBackgroundInitiated: isBackgroundInitiated
+    )
+  }
+}

--- a/ShareExtension/FeedlyService.swift
+++ b/ShareExtension/FeedlyService.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Valet
+
+enum FeedlyServiceError: Error, LocalizedError {
+    case notAuthenticated
+    case invalidURL
+    case notYouTubeURL
+    case networkError(String)
+    case serverError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated:
+            return "Please log in to the main app first"
+        case .invalidURL:
+            return "Invalid URL"
+        case .notYouTubeURL:
+            return "Only YouTube URLs are supported"
+        case .networkError(let message):
+            return message
+        case .serverError(let message):
+            return message
+        }
+    }
+}
+
+actor FeedlyService {
+    private let sharedGroupIdentifier = SharedGroupIdentifier(
+        appIDPrefix: "P328YB6M54",
+        nonEmptyGroup: "group.lifegames.OfflineMediaDownloader"
+    )!
+
+    private var keychain: Valet {
+        Valet.sharedGroupValet(with: sharedGroupIdentifier, accessibility: .whenUnlocked)
+    }
+
+    private var basePath: String {
+        Bundle.main.infoDictionary?["MEDIA_DOWNLOADER_BASE_PATH"] as? String ?? ""
+    }
+
+    private var apiKey: String {
+        Bundle.main.infoDictionary?["MEDIA_DOWNLOADER_API_KEY"] as? String ?? ""
+    }
+
+    func sendToFeedly(url: URL) async throws {
+        // Validate YouTube URL
+        guard YouTubeURLValidator.isYouTubeURL(url) else {
+            throw FeedlyServiceError.notYouTubeURL
+        }
+
+        // Get JWT token from shared keychain
+        guard let token = try? keychain.string(forKey: "jwtToken") else {
+            throw FeedlyServiceError.notAuthenticated
+        }
+
+        // Build request
+        guard let baseURL = URL(string: basePath) else {
+            throw FeedlyServiceError.networkError("Invalid base URL configuration")
+        }
+        let endpoint = baseURL.appendingPathComponent("feedly")
+        guard var urlComponents = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
+            throw FeedlyServiceError.networkError("Failed to build request URL")
+        }
+        urlComponents.queryItems = [URLQueryItem(name: "ApiKey", value: apiKey)]
+
+        guard let requestURL = urlComponents.url else {
+            throw FeedlyServiceError.networkError("Failed to build request URL")
+        }
+
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
+
+        let body: [String: Any] = [
+            "articleTitle": "Shared from YouTube",
+            "articleURL": url.absoluteString
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        // Send request
+        let (_, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw FeedlyServiceError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200, 202:
+            return // Success
+        case 401, 403:
+            throw FeedlyServiceError.notAuthenticated
+        case 400..<500:
+            throw FeedlyServiceError.networkError("Bad request: \(httpResponse.statusCode)")
+        default:
+            throw FeedlyServiceError.serverError("Server error: \(httpResponse.statusCode)")
+        }
+    }
+}

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Save to Downloader</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+	</dict>
+	<key>MEDIA_DOWNLOADER_API_KEY</key>
+	<string>$(MEDIA_DOWNLOADER_API_KEY)</string>
+	<key>MEDIA_DOWNLOADER_BASE_PATH</key>
+	<string>$(MEDIA_DOWNLOADER_BASE_PATH)</string>
+</dict>
+</plist>

--- a/ShareExtension/ShareExtension.entitlements
+++ b/ShareExtension/ShareExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.lifegames.OfflineMediaDownloader</string>
+	</array>
+</dict>
+</plist>

--- a/ShareExtension/ShareExtensionView.swift
+++ b/ShareExtension/ShareExtensionView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct ShareExtensionView: View {
+    enum Status {
+        case loading
+        case success
+        case error(String)
+    }
+
+    let status: Status
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            switch status {
+            case .loading:
+                ProgressView()
+                    .scaleEffect(1.5)
+                Text("Sending to Feedly...")
+                    .font(.headline)
+
+            case .success:
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 48))
+                    .foregroundColor(.green)
+                Text("Sent to Feedly")
+                    .font(.headline)
+
+            case .error(let message):
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 48))
+                    .foregroundColor(.red)
+                Text(message)
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+
+                Button("Dismiss") {
+                    onDismiss()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
+    }
+}
+
+#Preview("Loading") {
+    ShareExtensionView(status: .loading) {}
+}
+
+#Preview("Success") {
+    ShareExtensionView(status: .success) {}
+}
+
+#Preview("Error") {
+    ShareExtensionView(status: .error("Only YouTube URLs are supported")) {}
+}

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -1,0 +1,94 @@
+import UIKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+class ShareViewController: UIViewController {
+    private let feedlyService = FeedlyService()
+    private var hostingController: UIHostingController<ShareExtensionView>?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        showStatus(.loading)
+        processSharedContent()
+    }
+
+    private func showStatus(_ status: ShareExtensionView.Status) {
+        let contentView = ShareExtensionView(status: status) { [weak self] in
+            self?.dismissExtension()
+        }
+
+        if let hostingController = hostingController {
+            hostingController.rootView = contentView
+        } else {
+            let controller = UIHostingController(rootView: contentView)
+            addChild(controller)
+            controller.view.frame = self.view.bounds
+            controller.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            self.view.addSubview(controller.view)
+            controller.didMove(toParent: self)
+            hostingController = controller
+        }
+    }
+
+    private func processSharedContent() {
+        guard let item = extensionContext?.inputItems.first as? NSExtensionItem,
+              let attachments = item.attachments else {
+            showError("No content to share")
+            return
+        }
+
+        Task {
+            await processAttachments(attachments)
+        }
+    }
+
+    private func processAttachments(_ attachments: [NSItemProvider]) async {
+        for attachment in attachments {
+            if attachment.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
+                do {
+                    let url = try await loadURL(from: attachment)
+                    try await feedlyService.sendToFeedly(url: url)
+                    await MainActor.run {
+                        showStatus(.success)
+                        // Auto-dismiss after success
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+                            self?.dismissExtension()
+                        }
+                    }
+                    return
+                } catch let error as FeedlyServiceError {
+                    await MainActor.run { showError(error.localizedDescription) }
+                    return
+                } catch {
+                    await MainActor.run { showError("Failed to send: \(error.localizedDescription)") }
+                    return
+                }
+            }
+        }
+
+        await MainActor.run { showError("No URL found in shared content") }
+    }
+
+    private func loadURL(from attachment: NSItemProvider) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            attachment.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil) { item, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let url = item as? URL {
+                    continuation.resume(returning: url)
+                } else {
+                    continuation.resume(throwing: FeedlyServiceError.invalidURL)
+                }
+            }
+        }
+    }
+
+    private func showError(_ message: String) {
+        showStatus(.error(message))
+    }
+
+    private func dismissExtension() {
+        extensionContext?.completeRequest(returningItems: nil)
+    }
+}

--- a/ShareExtension/YouTubeURLValidator.swift
+++ b/ShareExtension/YouTubeURLValidator.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum YouTubeURLValidator {
+    private static let youtubeIDRegex: NSRegularExpression? = {
+        try? NSRegularExpression(
+            pattern: "((?<=(v|V)/)|(?<=be/)|(?<=(\\?|\\&)v=)|(?<=embed/))([\\w-]++)",
+            options: .caseInsensitive
+        )
+    }()
+
+    static func isYouTubeURL(_ url: URL) -> Bool {
+        let host = url.host?.lowercased() ?? ""
+        let validHosts = ["youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be"]
+
+        guard validHosts.contains(host) else { return false }
+
+        // For youtu.be, path should have video ID
+        if host == "youtu.be" {
+            return url.path.count > 1
+        }
+
+        // For youtube.com, check for v= parameter or /v/ path
+        let urlString = url.absoluteString
+        let range = NSRange(location: 0, length: urlString.count)
+        return youtubeIDRegex?.firstMatch(in: urlString, range: range) != nil
+    }
+
+    static func extractVideoID(from url: URL) -> String? {
+        let urlString = url.absoluteString
+        let range = NSRange(location: 0, length: urlString.count)
+        guard let result = youtubeIDRegex?.firstMatch(in: urlString, range: range) else {
+            return nil
+        }
+        return (urlString as NSString).substring(with: result.range)
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds an iOS Share Extension that allows users to share YouTube URLs from any app (like the YouTube app) directly to the Feedly webhook.

### Key Changes:
- **App Group entitlement** - Enables keychain sharing between main app and extension
- **Updated KeychainClient** - Uses shared group identifier for cross-target JWT token access
- **New ShareExtension target** with:
  - `YouTubeURLValidator` - Validates youtube.com and youtu.be URLs
  - `FeedlyService` - Lightweight API client (no TCA dependency)
  - `ShareExtensionView` - SwiftUI view with loading/success/error states
  - `ShareViewController` - Handles share sheet input

### Features:
- Requires user authentication (JWT token from main app)
- Validates URLs are YouTube before sending
- Shows minimal toast UI with auto-dismiss on success
- Displays helpful error messages for auth/validation failures

## Test Plan

- [ ] Build succeeds with both main app and ShareExtension targets
- [ ] All existing tests pass
- [ ] Share Extension appears in iOS Share Sheet when sharing URLs
- [ ] Authenticated user: YouTube URL is sent successfully, shows "Sent to Feedly"
- [ ] Unauthenticated user: Shows "Please log in to the main app first"
- [ ] Non-YouTube URL: Shows "Only YouTube URLs are supported"
- [ ] Extension auto-dismisses after successful send

## Screenshots

(To be added after manual testing)