### PR TITLE
chore(spm): bump OMDFeatures to swift-tools-version 6.2

### DIFF
--- a/Packages/OMDFeatures/Package.swift
+++ b/Packages/OMDFeatures/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
## Summary

One-line bump of `Packages/OMDFeatures/Package.swift`:

```diff
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
```

Aligns OMDFeatures with APITypes (already at 6.2) and with the rest of the monorepo (LP Swift 6.3, Cortex Swift 6.2). Unlocks Swift 6.2 features for future OMD code without requiring any source changes today.

## Why

A recent book assessment (Mastering Swift 6, 7th ed., Sep 2025) flagged the Swift version disparity across the monorepo and identified the OMDFeatures 6.1 → 6.2 bump as the only non-trivial catch-up action. After bumping:

- **Build**: `xcodebuild build` SUCCEEDED with 0 errors, 0 new Swift warnings
- **Test**: All 17 Swift Testing suites pass (verified against CI's exact simulator: iPhone 17 Pro Max iOS 26.2)
- **No source changes required** — existing code is already Sendable-compliant, uses the TCA Reducer protocol correctly, and captures dependencies before `.run` closures
- **No snapshot changes required** — verified the existing reference PNGs render byte-identically on the CI simulator

Notably, this PR does **NOT** enable `-default-isolation=MainActor` (SE-0466). That remains incompatible with the TCA nonisolated Reducer protocol and is explicitly banned in the monorepo `ios-concurrency.md` conventions.

## Swift 6.2 features unlocked for future code

- `Task(name:)` (SE-0469) — Instruments profiling
- `Task.immediate` (SE-0472) — avoids UI flicker on cached loads
- `weak let` (SE-0481) — Sendable compliance for immutable weak refs
- Exit tests `#expect(processExitsWith:)` (ST-0008) — verify fatalError paths
- `confirmation(expectedCount:)` range-based expectations in Swift Testing

Adoption is organic — no convention changes in this PR.

## Test plan

- [x] `xcodebuild build -scheme OfflineMediaDownloader` — SUCCEEDED
- [x] `xcodebuild test` on iPhone 17 Pro Max iOS 26.2 (CI simulator) — all 17 Swift Testing suites pass, 0 failures
- [x] Pre-commit hooks pass (no AI attribution, no sensitive files, no staged TODO/FIXME)
- [x] Pre-push build succeeds
- [ ] CI passes on this branch

## History note

This branch originally also included a `test(snapshots)` commit refreshing `FileCellSnapshotTests` reference PNGs. That commit was dropped after discovering that the original references are correct for the CI simulator (iPhone 17 Pro Max iOS 26.2) — the pixel-diff failures I saw locally were from an inconsistent local simulator (iPhone 17 Pro iOS 26.4), not the references being stale. Force-pushed to drop the errant commit.
