### PR TITLE
chore(openapi): sync regenerated spec from OMD

### DIFF
--- a/APITypes/Sources/APITypes/openapi.yaml
+++ b/APITypes/Sources/APITypes/openapi.yaml
@@ -1,656 +1,760 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: Offline Media Downloader API
-  description: |-
-    Offline Media Downloader API
-
-    A serverless AWS media downloader service that downloads media content
-    (primarily YouTube videos) and integrates with a companion iOS app for
-    offline playback.
-  version: 0.0.0
-tags:
-  - name: Files
-  - name: Devices
-  - name: Webhooks
-  - name: Authentication
+  version: 1.0.0
 paths:
+  /device/event:
+    post:
+      operationId: postDeviceEvent
+      responses:
+        "200":
+          description: Successful response
+        "400":
+          description: Bad request - validation failed or invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.InternalServerError"
   /device/register:
     post:
-      operationId: Devices_registerDevice
-      summary: Register device for push notifications
-      description: |-
-        Register a device to receive push notifications.
-
-        This is an idempotent operation that:
-        1. Creates an AWS SNS endpoint for the device
-        2. Associates the device with the authenticated user
-        3. Subscribes the device to push notification topics
-
-        Example request: See `tsp/examples/register-device-request.json`
-        (sourced from `src/lambdas/RegisterDevice/test/fixtures/apiRequest-POST-device.json`)
-
-        Example response: See `tsp/examples/register-device-response.json`
-        (sourced from `src/lambdas/RegisterDevice/test/fixtures/apiResponse-POST-200-OK.json`)
-      parameters:
-        - name: Authorization
-          in: header
-          required: true
-          schema:
-            type: string
-        - name: X-API-Key
-          in: header
-          required: true
-          schema:
-            type: string
+      operationId: postDeviceRegister
       responses:
-        '200':
-          description: Device registration confirmation with endpoint ARN
+        "200":
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Models.DeviceRegistrationResponse'
-        '201':
-          description: Device registration confirmation with endpoint ARN
+                $ref: "#/components/schemas/Models.DeviceRegistrationResponse"
+        "400":
+          description: Bad request - validation failed or invalid input
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Models.DeviceRegistrationResponse'
-        '400':
-          description: Device registration confirmation with endpoint ARN
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "401":
+          description: Unauthorized - authentication required or invalid
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '401':
-          description: Device registration confirmation with endpoint ARN
+                $ref: "#/components/schemas/Models.UnauthorizedError"
+        "403":
+          description: Forbidden - authenticated but not authorized for this resource
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UnauthorizedError'
-        '403':
-          description: Device registration confirmation with endpoint ARN
+                $ref: "#/components/schemas/Models.ForbiddenError"
+        "500":
+          description: Internal server error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ForbiddenError'
-        '500':
-          description: Device registration confirmation with endpoint ARN
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerError'
-      tags:
-        - Devices
+                $ref: "#/components/schemas/Models.InternalServerError"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Models.DeviceRegistrationRequest'
-  /feedly:
+              $ref: "#/components/schemas/Models.DeviceRegistrationRequest"
+  /feedly/webhook:
     post:
-      operationId: Webhooks_processFeedlyWebhook
-      summary: Process Feedly webhook
-      description: |-
-        Receive a webhook from Feedly to download media.
-
-        When a webhook is received:
-        - If the file exists: associates it with the user and sends push notification
-        - If the file doesn't exist: creates it, associates with user, and queues for download
-
-        Background mode can be used to defer immediate download processing.
-
-        Example request: See `tsp/examples/webhook-feedly-request.json`
-        (sourced from `src/lambdas/WebhookFeedly/test/fixtures/apiRequest-POST-webhook.json`)
-
-        Example response: See `tsp/examples/webhook-feedly-response.json`
-        (sourced from `src/lambdas/WebhookFeedly/test/fixtures/apiResponse-POST-200-OK.json`)
-      parameters:
-        - name: Authorization
-          in: header
-          required: true
-          schema:
-            type: string
-        - name: X-API-Key
-          in: header
-          required: true
-          schema:
-            type: string
+      operationId: postFeedlyWebhook
       responses:
-        '200':
-          description: Webhook processing status
+        "200":
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Models.WebhookResponse'
-        '202':
-          description: Webhook processing status
+                $ref: "#/components/schemas/Models.WebhookResponse"
+        "400":
+          description: Bad request - validation failed or invalid input
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Models.WebhookResponse'
-        '400':
-          description: Webhook processing status
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "401":
+          description: Unauthorized - authentication required or invalid
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '403':
-          description: Webhook processing status
+                $ref: "#/components/schemas/Models.UnauthorizedError"
+        "403":
+          description: Forbidden - authenticated but not authorized for this resource
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ForbiddenError'
-        '500':
-          description: Webhook processing status
+                $ref: "#/components/schemas/Models.ForbiddenError"
+        "500":
+          description: Internal server error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InternalServerError'
-      tags:
-        - Webhooks
+                $ref: "#/components/schemas/Models.InternalServerError"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Models.FeedlyWebhook'
+              $ref: "#/components/schemas/Models.FeedlyWebhookRequest"
   /files:
     get:
-      operationId: Files_listFiles
-      summary: List available files
-      description: |-
-        List all files available to the authenticated user.
-
-        Returns files based on authentication status:
-        - Authenticated users: returns their personal file library
-        - Anonymous users: returns a demo file for training purposes
-        - Unauthenticated users: returns 401 Unauthorized
-
-        Example response: See `tsp/examples/list-files-response.json`
-        (sourced from `src/lambdas/ListFiles/test/fixtures/apiResponse-GET-200-OK.json`)
-      parameters:
-        - name: Authorization
-          in: header
-          required: true
-          schema:
-            type: string
-        - name: X-API-Key
-          in: header
-          required: true
-          schema:
-            type: string
+      operationId: getFiles
       responses:
-        '200':
-          description: List of available files
+        "200":
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Models.FileListResponse'
-        '401':
-          description: List of available files
+                $ref: "#/components/schemas/Models.FileListResponse"
+        "400":
+          description: Bad request - validation failed or invalid input
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UnauthorizedError'
-        '403':
-          description: List of available files
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "401":
+          description: Unauthorized - authentication required or invalid
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ForbiddenError'
-        '500':
-          description: List of available files
+                $ref: "#/components/schemas/Models.UnauthorizedError"
+        "403":
+          description: Forbidden - authenticated but not authorized for this resource
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InternalServerError'
-      tags:
-        - Files
+                $ref: "#/components/schemas/Models.ForbiddenError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.InternalServerError"
+      parameters:
+        - name: status
+          in: query
+          required: true
+          schema: &a1
+            default: downloaded
+            type: string
+  /user:
+    delete:
+      operationId: deleteUser
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.PartialDeletionResponse"
+        "400":
+          description: Bad request - validation failed or invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "401":
+          description: Unauthorized - authentication required or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.UnauthorizedError"
+        "403":
+          description: Forbidden - authenticated but not authorized for this resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ForbiddenError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.InternalServerError"
   /user/login:
     post:
-      operationId: Authentication_loginUser
-      summary: Login existing user
-      description: |-
-        Login an existing user with Sign in with Apple.
-
-        Authenticates a user and returns a JWT access token.
-
-        Example request: See `tsp/examples/login-user-request.json`
-        (sourced from `src/lambdas/LoginUser/test/fixtures/apiRequest-POST-login.json`)
-
-        Example response: See `tsp/examples/login-user-response.json`
-        (sourced from `src/lambdas/LoginUser/test/fixtures/apiResponse-POST-200-OK.json`)
-      parameters:
-        - name: X-API-Key
-          in: header
-          required: true
-          schema:
-            type: string
+      operationId: postUserLogin
       responses:
-        '200':
-          description: JWT access token
+        "200":
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Models.UserLoginResponse'
-        '400':
-          description: JWT access token
+                $ref: "#/components/schemas/Models.UserLoginResponse"
+        "400":
+          description: Bad request - validation failed or invalid input
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '403':
-          description: JWT access token
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "500":
+          description: Internal server error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ForbiddenError'
-        '404':
-          description: JWT access token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '409':
-          description: JWT access token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: JWT access token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerError'
-      tags:
-        - Authentication
+                $ref: "#/components/schemas/Models.InternalServerError"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Models.UserLogin'
+              $ref: "#/components/schemas/Models.LoginRequest"
+  /user/logout:
+    post:
+      operationId: postUserLogout
+      responses:
+        "200":
+          description: Successful response
+        "400":
+          description: Bad request - validation failed or invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "401":
+          description: Unauthorized - authentication required or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.UnauthorizedError"
+        "403":
+          description: Forbidden - authenticated but not authorized for this resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ForbiddenError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.InternalServerError"
+  /user/refresh:
+    post:
+      operationId: postUserRefresh
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.UserLoginResponse"
+        "400":
+          description: Bad request - validation failed or invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "401":
+          description: Unauthorized - authentication required or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.UnauthorizedError"
+        "403":
+          description: Forbidden - authenticated but not authorized for this resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ForbiddenError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.InternalServerError"
   /user/register:
     post:
-      operationId: Authentication_registerUser
-      summary: Register new user
-      description: |-
-        Register a new user with Sign in with Apple.
-
-        Creates a new user account or returns existing user token.
-        All user details are sourced from the Apple identity token.
-
-        Example request: See `tsp/examples/register-user-request.json`
-        (sourced from `src/lambdas/RegisterUser/test/fixtures/apiRequest-POST-register.json`)
-
-        Example response: See `tsp/examples/register-user-response.json`
-        (sourced from `src/lambdas/RegisterUser/test/fixtures/apiResponse-POST-200-OK.json`)
-      parameters:
-        - name: X-API-Key
-          in: header
-          required: true
-          schema:
-            type: string
+      operationId: postUserRegister
       responses:
-        '200':
-          description: JWT access token
+        "200":
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Models.UserRegistrationResponse'
-        '400':
-          description: JWT access token
+                $ref: "#/components/schemas/Models.UserRegistrationResponse"
+        "400":
+          description: Bad request - validation failed or invalid input
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '403':
-          description: JWT access token
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "500":
+          description: Internal server error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ForbiddenError'
-        '500':
-          description: JWT access token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerError'
-      tags:
-        - Authentication
+                $ref: "#/components/schemas/Models.InternalServerError"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Models.UserRegistration'
+              $ref: "#/components/schemas/Models.RegistrationRequest"
+  /user/subscribe:
+    post:
+      operationId: postUserSubscribe
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.SubscriptionResponse"
+        "400":
+          description: Bad request - validation failed or invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "401":
+          description: Unauthorized - authentication required or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.UnauthorizedError"
+        "403":
+          description: Forbidden - authenticated but not authorized for this resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ForbiddenError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.InternalServerError"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Models.SubscriptionRequest"
 components:
   schemas:
-    ErrorResponse:
+    Models.DeviceRegistrationRequest:
+      $schema: https://json-schema.org/draft/2020-12/schema
       type: object
-      required:
-        - error
-        - requestId
       properties:
-        error:
-          type: object
-          properties:
-            code:
-              type: string
-              description: Error code
-            message:
-              type: string
-              description: Error message
-          required:
-            - code
-            - message
-          description: Error details
-        requestId:
+        deviceId:
           type: string
-          description: Request ID for tracking
-      description: Common error response structure
-    ForbiddenError:
-      type: object
-      required:
-        - error
-        - requestId
-      properties:
-        error:
-          type: object
-          properties:
-            code:
-              type: string
-              enum:
-                - Forbidden
-              description: Error code
-            message:
-              type: string
-              description: Error message
-          required:
-            - code
-            - message
-          description: Error details
-        requestId:
+        name:
           type: string
-          description: Request ID for tracking
-      description: Forbidden error response (403)
-    InternalServerError:
-      type: object
-      required:
-        - error
-        - requestId
-      properties:
-        error:
-          type: object
-          properties:
-            code:
-              type: string
-              enum:
-                - InternalServerError
-              description: Error code
-            message:
-              type: string
-              description: Error message
-          required:
-            - code
-            - message
-          description: Error details
-        requestId:
+        systemName:
           type: string
-          description: Request ID for tracking
-      description: Internal Server Error response (500)
-    Models.Device:
-      type: object
+        systemVersion:
+          type: string
+        token:
+          type: string
       required:
         - deviceId
         - name
         - systemName
         - systemVersion
         - token
+      additionalProperties: false
+      id: DeviceRegistrationRequest
+    Models.ClientEventRequest:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
       properties:
-        deviceId:
+        message:
           type: string
-          description: Unique device identifier (UUID)
-        name:
-          type: string
-          description: Device name
-        systemName:
-          type: string
-          description: Operating system name
-        systemVersion:
-          type: string
-          description: Operating system version
-        token:
-          type: string
-          description: Device push notification token
+      required:
+        - message
+      additionalProperties: false
+      id: ClientEventRequest
+    Models.DeviceRegistrationResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
         endpointArn:
           type: string
-          description: AWS SNS endpoint ARN (returned after registration)
-      description: Device information for push notifications
-    Models.DeviceRegistrationRequest:
-      type: object
-      required:
-        - deviceId
-        - name
-        - systemName
-        - systemVersion
-        - token
-      properties:
-        deviceId:
-          type: string
-          description: Unique device identifier (UUID)
-        name:
-          type: string
-          description: Device name
-        systemName:
-          type: string
-          description: Operating system name
-        systemVersion:
-          type: string
-          description: Operating system version
-        token:
-          type: string
-          description: Device push notification token (APNS token)
-      description: Device registration request
-    Models.DeviceRegistrationResponse:
-      type: object
       required:
         - endpointArn
+      additionalProperties: false
+      id: DeviceRegistrationResponse
+    Models.Device:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
       properties:
+        deviceId:
+          type: string
+        name:
+          type: string
+        systemName:
+          type: string
+        systemVersion:
+          type: string
+        token:
+          type: string
         endpointArn:
           type: string
-          description: AWS SNS endpoint ARN for the registered device
-      description: Device registration response
-    Models.FeedlyWebhook:
-      type: object
       required:
-        - articleTitle
-        - articleURL
+        - deviceId
+        - name
+        - systemName
+        - systemVersion
+        - token
+      additionalProperties: false
+      id: Device
+    Models.ErrorResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
       properties:
-        articleFirstImageURL:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+          required:
+            - code
+            - message
+          additionalProperties: false
+        requestId:
           type: string
-          format: uri
-          description: URL of the first image in the article
-        articleCategories:
-          type: string
-          description: Categories associated with the article
-        articlePublishedAt:
-          type: string
-          description: Publication date of the article
-        articleTitle:
-          type: string
-          description: Title of the article
+      required:
+        - error
+        - requestId
+      additionalProperties: false
+      id: ErrorResponse
+    Models.FeedlyWebhookRequest:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
         articleURL:
           type: string
-          format: uri
-          description: URL of the article (typically a YouTube video URL)
-        createdAt:
-          type: string
-          description: Timestamp when the webhook was created
-        sourceFeedURL:
-          type: string
-          format: uri
-          description: URL of the source feed
-        sourceTitle:
-          type: string
-          description: Title of the source
-        sourceURL:
-          type: string
-          format: uri
-          description: URL of the source
-        backgroundMode:
-          type: boolean
-          description: Whether the webhook was triggered in background mode
-      description: Feedly webhook event
-    Models.File:
-      type: object
       required:
-        - fileId
-      properties:
-        fileId:
-          type: string
-          description: The unique file identifier (typically a YouTube video ID)
-        key:
-          type: string
-          description: The filename or key in S3 storage
-        size:
-          type: integer
-          format: int64
-          description: Size in bytes of the file
-        status:
-          allOf:
-            - $ref: '#/components/schemas/Models.FileStatus'
-          description: Current status of the file
-        title:
-          type: string
-          description: Title of the media file
-        publishDate:
-          type: string
-          description: Video publish date
-        authorName:
-          type: string
-          description: Channel/author display name
-        authorUser:
-          type: string
-          description: Channel/author username or ID
-        contentType:
-          type: string
-          description: MIME type (e.g., video/mp4)
-        description:
-          type: string
-          description: Video description
-        url:
-          type: string
-          format: uri
-          description: CloudFront URL for downloading the file
-      description: A media file available for download
+        - articleURL
+      additionalProperties: false
+      id: FeedlyWebhookRequest
     Models.FileListResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
       type: object
-      required:
-        - contents
-        - keyCount
       properties:
         contents:
           type: array
           items:
-            $ref: '#/components/schemas/Models.File'
-          description: Array of available files
+            $ref: "#/components/schemas/Models.File"
         keyCount:
-          type: integer
-          format: int32
-          description: Number of files returned
-      description: Response containing a list of files
+          type: number
+      required:
+        - contents
+        - keyCount
+      additionalProperties: false
+      id: FileListResponse
+    Models.File:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        fileId:
+          type: string
+        key:
+          type: string
+        size:
+          type: number
+        status:
+          type: string
+          enum:
+            - Queued
+            - Downloading
+            - Downloaded
+            - Failed
+        title:
+          type: string
+        publishDate:
+          type: string
+        authorName:
+          type: string
+        authorUser:
+          type: string
+        contentType:
+          type: string
+        description:
+          type: string
+        url:
+          type: string
+          format: uri
+        duration:
+          type: number
+        uploadDate:
+          type: string
+        viewCount:
+          type: number
+        thumbnailUrl:
+          type: string
+          format: uri
+      required:
+        - fileId
+      additionalProperties: false
+      id: File
     Models.FileStatus:
+      $schema: https://json-schema.org/draft/2020-12/schema
       type: string
       enum:
         - Queued
         - Downloading
         - Downloaded
         - Failed
-      description: File status enumeration
-    Models.UserLogin:
+      id: FileStatus
+    Models.ForbiddenError:
+      $schema: https://json-schema.org/draft/2020-12/schema
       type: object
-      required:
-        - authorizationCode
-      properties:
-        authorizationCode:
-          type: string
-          description: Authorization code from Sign in with Apple
-      description: User login request
-    Models.UserLoginResponse:
-      type: object
-      required:
-        - token
-      properties:
-        token:
-          type: string
-          description: JWT access token for authenticated requests
-      description: User login response
-    Models.UserRegistration:
-      type: object
-      required:
-        - authorizationCode
-      properties:
-        authorizationCode:
-          type: string
-          description: Authorization code from Sign in with Apple
-        firstName:
-          type: string
-          description: User's first name
-        lastName:
-          type: string
-          description: User's last name
-      description: User registration request
-    Models.UserRegistrationResponse:
-      type: object
-      required:
-        - token
-      properties:
-        token:
-          type: string
-          description: JWT access token for authenticated requests
-      description: User registration response
-    Models.WebhookResponse:
-      type: object
-      required:
-        - status
-      properties:
-        status:
-          type: string
-          enum:
-            - Dispatched
-            - Initiated
-            - Accepted
-          description: Status of the webhook processing
-      description: Webhook processing response
-    UnauthorizedError:
-      type: object
-      required:
-        - error
-        - requestId
       properties:
         error:
           type: object
           properties:
             code:
               type: string
-              enum:
-                - Unauthorized
-              description: Error code
             message:
               type: string
-              description: Error message
           required:
             - code
             - message
-          description: Error details
+          additionalProperties: false
         requestId:
           type: string
-          description: Request ID for tracking
-      description: Unauthorized error response (401)
-servers:
-  - url: https://api.example.com
-    description: Production server
-    variables: {}
+      required:
+        - error
+        - requestId
+      additionalProperties: false
+      id: ForbiddenError
+    Models.InternalServerError:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+          required:
+            - code
+            - message
+          additionalProperties: false
+        requestId:
+          type: string
+      required:
+        - error
+        - requestId
+      additionalProperties: false
+      id: InternalServerError
+    Models.TokenRefreshResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        token:
+          type: string
+        expiresAt:
+          type: string
+        sessionId:
+          type: string
+        userId:
+          type: string
+      required:
+        - token
+        - expiresAt
+        - sessionId
+        - userId
+      additionalProperties: false
+      id: TokenRefreshResponse
+    Models.UnauthorizedError:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+          required:
+            - code
+            - message
+          additionalProperties: false
+        requestId:
+          type: string
+      required:
+        - error
+        - requestId
+      additionalProperties: false
+      id: UnauthorizedError
+    Models.UserLoginRequest:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        idToken:
+          type: string
+      required:
+        - idToken
+      additionalProperties: false
+      id: UserLoginRequest
+    Models.UserLoginResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        token:
+          type: string
+        expiresAt:
+          type: string
+        sessionId:
+          type: string
+        userId:
+          type: string
+      required:
+        - token
+        - expiresAt
+        - sessionId
+        - userId
+      additionalProperties: false
+      id: UserLoginResponse
+    Models.UserRegistrationRequest:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        idToken:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+      required:
+        - idToken
+      additionalProperties: false
+      id: UserRegistrationRequest
+    Models.UserRegistrationResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        token:
+          type: string
+        expiresAt:
+          type: string
+        sessionId:
+          type: string
+        userId:
+          type: string
+      required:
+        - token
+        - expiresAt
+        - sessionId
+        - userId
+      additionalProperties: false
+      id: UserRegistrationResponse
+    Models.UserSubscriptionRequest:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        endpointArn:
+          type: string
+        topicArn:
+          type: string
+      required:
+        - endpointArn
+        - topicArn
+      additionalProperties: false
+      id: UserSubscriptionRequest
+    Models.UserSubscriptionResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        subscriptionArn:
+          type: string
+      required:
+        - subscriptionArn
+      additionalProperties: false
+      id: UserSubscriptionResponse
+    Models.WebhookResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        status:
+          anyOf:
+            - type: string
+              const: Dispatched
+            - type: string
+              const: Initiated
+            - type: string
+              const: Accepted
+      required:
+        - status
+      additionalProperties: false
+      id: WebhookResponse
+    Models.ListFilesQuery:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        status: *a1
+      required:
+        - status
+      additionalProperties: false
+      id: ListFilesQuery
+    Models.PartialDeletionResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        message:
+          type: string
+        failedOperations:
+          type: number
+      required:
+        - message
+        - failedOperations
+      additionalProperties: false
+      id: PartialDeletionResponse
+    Models.LoginRequest:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        idToken:
+          type: string
+      required:
+        - idToken
+      additionalProperties: false
+      id: LoginRequest
+    Models.RegistrationRequest:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        idToken:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+      required:
+        - idToken
+      additionalProperties: false
+      id: RegistrationRequest
+    Models.SubscriptionRequest:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        endpointArn:
+          type: string
+        topicArn:
+          type: string
+      required:
+        - endpointArn
+        - topicArn
+      additionalProperties: false
+      id: SubscriptionRequest
+    Models.SubscriptionResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        subscriptionArn:
+          type: string
+      additionalProperties: false
+      id: SubscriptionResponse

--- a/App/Models/File.swift
+++ b/App/Models/File.swift
@@ -1,171 +1,176 @@
-import Foundation
-import CoreData
 import APITypes
+import CoreData
+import Foundation
 
-// Cached date formatter for YYYYMMDD format (API responses)
+/// Cached date formatter for YYYYMMDD format (API responses)
 private let fileDateFormatter: DateFormatter = {
-  let formatter = DateFormatter()
-  formatter.dateFormat = "yyyyMMdd"
-  formatter.timeZone = TimeZone(secondsFromGMT: 0)
-  return formatter
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyyMMdd"
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    return formatter
 }()
 
-// Cached date formatter for ISO date format (push notifications)
+/// Cached date formatter for ISO date format (push notifications)
 private let fileDateFormatterISO: DateFormatter = {
-  let formatter = DateFormatter()
-  formatter.dateFormat = "yyyy-MM-dd"
-  formatter.timeZone = TimeZone(secondsFromGMT: 0)
-  return formatter
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd"
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    return formatter
 }()
 
-struct File: Equatable, Identifiable, Codable, Sendable {
-  var fileId: String
-  var key: String
-  var publishDate: Date?
-  var size: Int?
-  var url: URL?
-  // Additional fields from backend
-  var authorName: String?
-  var authorUser: String?
-  var contentType: String?
-  var description: String?
-  var status: FileStatus?
-  var title: String?
+struct File: Equatable, Identifiable, Codable {
+    var fileId: String
+    var key: String
+    var publishDate: Date?
+    var size: Int?
+    var url: URL?
+    // Additional fields from backend
+    var authorName: String?
+    var authorUser: String?
+    var contentType: String?
+    var description: String?
+    var status: FileStatus?
+    var title: String?
 
-  var id: String { fileId }
-
-  enum CodingKeys: String, CodingKey {
-    case fileId, key, publishDate, size, url
-    case authorName, authorUser, contentType, description, status, title
-  }
-
-  init(fileId: String, key: String, publishDate: Date? = nil, size: Int? = nil, url: URL? = nil) {
-    self.fileId = fileId
-    self.key = key
-    self.publishDate = publishDate
-    self.size = size
-    self.url = url
-  }
-
-  init(from decoder: Decoder) throws {
-    let values = try decoder.container(keyedBy: CodingKeys.self)
-    fileId = try values.decode(String.self, forKey: .fileId)
-    key = try values.decode(String.self, forKey: .key)
-    size = try values.decodeIfPresent(Int.self, forKey: .size)
-
-    // URL is optional - backend may not include it
-    if let urlString = try values.decodeIfPresent(String.self, forKey: .url) {
-      url = URL(string: urlString)
+    var id: String {
+        fileId
     }
 
-    // Parse date - try YYYYMMDD first (API), then ISO date (push notifications)
-    if let dateString = try values.decodeIfPresent(String.self, forKey: .publishDate) {
-      publishDate = fileDateFormatter.date(from: dateString)
-                 ?? fileDateFormatterISO.date(from: dateString)
+    enum CodingKeys: String, CodingKey {
+        case fileId, key, publishDate, size, url
+        case authorName, authorUser, contentType, description, status, title
     }
 
-    // Decode additional optional fields
-    authorName = try values.decodeIfPresent(String.self, forKey: .authorName)
-    authorUser = try values.decodeIfPresent(String.self, forKey: .authorUser)
-    contentType = try values.decodeIfPresent(String.self, forKey: .contentType)
-    description = try values.decodeIfPresent(String.self, forKey: .description)
-    status = try values.decodeIfPresent(FileStatus.self, forKey: .status)
-    title = try values.decodeIfPresent(String.self, forKey: .title)
-  }
-
-  func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(fileId, forKey: .fileId)
-    try container.encode(key, forKey: .key)
-    try container.encodeIfPresent(size, forKey: .size)
-    try container.encodeIfPresent(url?.absoluteString, forKey: .url)
-    if let date = publishDate {
-      try container.encode(fileDateFormatter.string(from: date), forKey: .publishDate)
+    init(fileId: String, key: String, publishDate: Date? = nil, size: Int? = nil, url: URL? = nil) {
+        self.fileId = fileId
+        self.key = key
+        self.publishDate = publishDate
+        self.size = size
+        self.url = url
     }
-    try container.encodeIfPresent(authorName, forKey: .authorName)
-    try container.encodeIfPresent(authorUser, forKey: .authorUser)
-    try container.encodeIfPresent(contentType, forKey: .contentType)
-    try container.encodeIfPresent(description, forKey: .description)
-    try container.encodeIfPresent(status, forKey: .status)
-    try container.encodeIfPresent(title, forKey: .title)
-  }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        fileId = try values.decode(String.self, forKey: .fileId)
+        key = try values.decode(String.self, forKey: .key)
+        size = try values.decodeIfPresent(Int.self, forKey: .size)
+
+        // URL is optional - backend may not include it
+        if let urlString = try values.decodeIfPresent(String.self, forKey: .url) {
+            url = URL(string: urlString)
+        }
+
+        // Parse date - try YYYYMMDD first (API), then ISO date (push notifications)
+        if let dateString = try values.decodeIfPresent(String.self, forKey: .publishDate) {
+            publishDate = fileDateFormatter.date(from: dateString)
+                ?? fileDateFormatterISO.date(from: dateString)
+        }
+
+        // Decode additional optional fields
+        authorName = try values.decodeIfPresent(String.self, forKey: .authorName)
+        authorUser = try values.decodeIfPresent(String.self, forKey: .authorUser)
+        contentType = try values.decodeIfPresent(String.self, forKey: .contentType)
+        description = try values.decodeIfPresent(String.self, forKey: .description)
+        status = try values.decodeIfPresent(FileStatus.self, forKey: .status)
+        title = try values.decodeIfPresent(String.self, forKey: .title)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(fileId, forKey: .fileId)
+        try container.encode(key, forKey: .key)
+        try container.encodeIfPresent(size, forKey: .size)
+        try container.encodeIfPresent(url?.absoluteString, forKey: .url)
+        if let date = publishDate {
+            try container.encode(fileDateFormatter.string(from: date), forKey: .publishDate)
+        }
+        try container.encodeIfPresent(authorName, forKey: .authorName)
+        try container.encodeIfPresent(authorUser, forKey: .authorUser)
+        try container.encodeIfPresent(contentType, forKey: .contentType)
+        try container.encodeIfPresent(description, forKey: .description)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(title, forKey: .title)
+    }
 }
 
 // MARK: - CoreData Mapping
+
 extension File {
-  /// Initialize from CoreData FileEntity
-  init(entity: FileEntity) {
-    self.fileId = entity.fileId ?? ""
-    self.key = entity.key ?? ""
-    self.publishDate = entity.publishDate
-    self.size = entity.size == 0 ? nil : Int(entity.size)
-    self.url = entity.url.flatMap { URL(string: $0) }
-    self.authorName = entity.authorName
-    self.authorUser = entity.authorUser
-    self.contentType = entity.contentType
-    self.description = entity.fileDescription
-    self.status = entity.status.flatMap { FileStatus(rawValue: $0) }
-    self.title = entity.title
-  }
-
-  /// Update or create a FileEntity from this File
-  func toEntity(in context: NSManagedObjectContext) -> FileEntity {
-    // Try to find existing entity with same fileId
-    let request = FileEntity.fetchRequest()
-    request.predicate = NSPredicate(format: "fileId == %@", fileId)
-    request.fetchLimit = 1
-
-    let entity: FileEntity
-    if let existing = try? context.fetch(request).first {
-      entity = existing
-    } else {
-      entity = FileEntity(context: context)
+    /// Initialize from CoreData FileEntity
+    init(entity: FileEntity) {
+        fileId = entity.fileId ?? ""
+        key = entity.key ?? ""
+        publishDate = entity.publishDate
+        size = entity.size == 0 ? nil : Int(entity.size)
+        url = entity.url.flatMap { URL(string: $0) }
+        authorName = entity.authorName
+        authorUser = entity.authorUser
+        contentType = entity.contentType
+        description = entity.fileDescription
+        status = entity.status.flatMap { FileStatus(rawValue: $0) }
+        title = entity.title
     }
 
-    entity.fileId = fileId
-    entity.key = key
-    entity.publishDate = publishDate
-    entity.size = Int64(size ?? 0)
-    entity.url = url?.absoluteString
-    entity.authorName = authorName
-    entity.authorUser = authorUser
-    entity.contentType = contentType
-    entity.fileDescription = description
-    entity.status = status?.rawValue
-    entity.title = title
+    /// Update or create a FileEntity from this File
+    func toEntity(in context: NSManagedObjectContext) -> FileEntity {
+        // Try to find existing entity with same fileId
+        let request = FileEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "fileId == %@", fileId)
+        request.fetchLimit = 1
 
-    return entity
-  }
+        let entity: FileEntity
+        if let existing = try? context.fetch(request).first {
+            entity = existing
+        } else {
+            entity = FileEntity(context: context)
+        }
+
+        entity.fileId = fileId
+        entity.key = key
+        entity.publishDate = publishDate
+        entity.size = Int64(size ?? 0)
+        entity.url = url?.absoluteString
+        entity.authorName = authorName
+        entity.authorUser = authorUser
+        entity.contentType = contentType
+        entity.fileDescription = description
+        entity.status = status?.rawValue
+        entity.title = title
+
+        return entity
+    }
 }
 
 // MARK: - Generated Type Conversion
+
 extension File {
-  /// Initialize from generated API type
-  init(from api: APIFile) {
-    self.fileId = api.fileId
-    self.key = api.key ?? ""
-    self.size = api.size.map { Int($0) }
-    self.url = api.url.flatMap { URL(string: $0) }
-    self.authorName = api.authorName
-    self.authorUser = api.authorUser
-    self.contentType = api.contentType
-    self.description = api.description
-    self.title = api.title
+    /// Initialize from generated API type
+    init(from api: APIFile) {
+        fileId = api.fileId
+        key = api.key ?? ""
+        size = api.size.map { Int($0) }
+        url = api.url.flatMap { URL(string: $0) }
+        authorName = api.authorName
+        authorUser = api.authorUser
+        contentType = api.contentType
+        description = api.description
+        title = api.title
 
-    // Convert generated FileStatus enum to domain FileStatus
-    // The generator wraps allOf references in a payload struct with value1
-    if let apiStatus = api.status?.value1 {
-      self.status = FileStatus(from: apiStatus)
-    } else {
-      self.status = nil
-    }
+        // Convert generated FileStatus enum to domain FileStatus via rawValue bridge.
+        // The generated statusPayload enum and domain FileStatus share identical
+        // raw string values (Queued, Downloading, Downloaded, Failed).
+        if let rawStatus = api.status?.rawValue {
+            status = FileStatus(rawValue: rawStatus)
+        } else {
+            status = nil
+        }
 
-    // Parse publish date from string
-    if let dateString = api.publishDate {
-      self.publishDate = fileDateFormatter.date(from: dateString)
-                       ?? fileDateFormatterISO.date(from: dateString)
-    } else {
-      self.publishDate = nil
+        // Parse publish date from string
+        if let dateString = api.publishDate {
+            publishDate = fileDateFormatter.date(from: dateString)
+                ?? fileDateFormatterISO.date(from: dateString)
+        } else {
+            publishDate = nil
+        }
     }
-  }
 }

--- a/App/Models/GeneratedTypes.swift
+++ b/App/Models/GeneratedTypes.swift
@@ -1,32 +1,38 @@
 import APITypes
 
 // MARK: - Type Aliases for Generated API Types
+
 // Maps generated types from swift-openapi-generator to more convenient names.
 // Generated types follow the pattern: Components.Schemas.{SchemaName}
 // where dots in schema names become underscores (e.g., Models.File -> Models_File)
 
 // MARK: - File Types
+
 public typealias APIFile = Components.Schemas.Models_period_File
 public typealias APIFileStatus = Components.Schemas.Models_period_FileStatus
 public typealias APIFileListResponse = Components.Schemas.Models_period_FileListResponse
 
 // MARK: - Device Types
+
 public typealias APIDevice = Components.Schemas.Models_period_Device
 public typealias APIDeviceRegistrationRequest = Components.Schemas.Models_period_DeviceRegistrationRequest
 public typealias APIDeviceRegistrationResponse = Components.Schemas.Models_period_DeviceRegistrationResponse
 
 // MARK: - User/Auth Types
-public typealias APIUserLogin = Components.Schemas.Models_period_UserLogin
+
+public typealias APIUserLogin = Components.Schemas.Models_period_UserLoginRequest
 public typealias APIUserLoginResponse = Components.Schemas.Models_period_UserLoginResponse
-public typealias APIUserRegistration = Components.Schemas.Models_period_UserRegistration
+public typealias APIUserRegistration = Components.Schemas.Models_period_UserRegistrationRequest
 public typealias APIUserRegistrationResponse = Components.Schemas.Models_period_UserRegistrationResponse
 
 // MARK: - Webhook Types
-public typealias APIFeedlyWebhook = Components.Schemas.Models_period_FeedlyWebhook
+
+public typealias APIFeedlyWebhook = Components.Schemas.Models_period_FeedlyWebhookRequest
 public typealias APIWebhookResponse = Components.Schemas.Models_period_WebhookResponse
 
 // MARK: - Error Types
-public typealias APIErrorResponse = Components.Schemas.ErrorResponse
-public typealias APIForbiddenError = Components.Schemas.ForbiddenError
-public typealias APIUnauthorizedError = Components.Schemas.UnauthorizedError
-public typealias APIInternalServerError = Components.Schemas.InternalServerError
+
+public typealias APIErrorResponse = Components.Schemas.Models_period_ErrorResponse
+public typealias APIForbiddenError = Components.Schemas.Models_period_ForbiddenError
+public typealias APIUnauthorizedError = Components.Schemas.Models_period_UnauthorizedError
+public typealias APIInternalServerError = Components.Schemas.Models_period_InternalServerError

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,5 @@
+# See AGENTS.md
+
+This project uses AGENTS.md as the single source of truth for AI coding assistant context.
+
+Please see AGENTS.md in the repository root for comprehensive project documentation and guidelines.


### PR DESCRIPTION
## Summary

- **GET /files**: migrated from `requestBody` to `parameters` (query params) — aligns with the `querySchema` fix in mantle-OfflineMediaDownloader#470
- **`FileListResponse.contents.items`**: promoted from inline schema to `$ref: Models.File` — reduces duplication in the spec
- **OpenAPI version**: bumped from 3.0.0 → 3.1.0 (upstream generator change)
- **Schema renames** (same data, new names): `UserLogin` → `UserLoginRequest`, `UserRegistration` → `UserRegistrationRequest`, `FeedlyWebhook` → `FeedlyWebhookRequest`; error types now under `Models.*` prefix
- **`GeneratedTypes.swift`** updated to match new schema names — `Components.Schemas` aliases corrected for all renamed types

Depends on: mantle-OfflineMediaDownloader#470 (merged)

## Test plan

- [x] `APITypes` swift package builds cleanly (`swift build` in `APITypes/` — exit 0)
- [x] Full Xcode build passes (`xcodebuild` via pre-push hook — exit 0, no errors)
- [ ] Smoke test GET /files in the running app against staging backend