### PR TITLE
feat: download-started notification + server-backed file delete

### DIFF
--- a/APITypes/Sources/APITypes/openapi.yaml
+++ b/APITypes/Sources/APITypes/openapi.yaml
@@ -135,12 +135,53 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Models.InternalServerError"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Models.ListFilesQuery"
+      parameters:
+        - name: status
+          in: query
+          required: true
+          schema: &a1
+            default: downloaded
+            type: string
+  /files/{fileId}:
+    delete:
+      operationId: deleteFilesByFileId
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.DeleteFileResponse"
+        "400":
+          description: Bad request - validation failed or invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "401":
+          description: Unauthorized - authentication required or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.UnauthorizedError"
+        "403":
+          description: Forbidden - authenticated but not authorized for this resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ForbiddenError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.InternalServerError"
+      parameters:
+        - name: fileId
+          in: path
+          required: true
+          schema:
+            type: string
   /user:
     delete:
       operationId: deleteUser
@@ -442,48 +483,7 @@ components:
         contents:
           type: array
           items:
-            type: object
-            properties:
-              fileId:
-                type: string
-              key:
-                type: string
-              size:
-                type: number
-              status:
-                type: string
-                enum:
-                  - Queued
-                  - Downloading
-                  - Downloaded
-                  - Failed
-              title:
-                type: string
-              publishDate:
-                type: string
-              authorName:
-                type: string
-              authorUser:
-                type: string
-              contentType:
-                type: string
-              description:
-                type: string
-              url:
-                type: string
-                format: uri
-              duration:
-                type: number
-              uploadDate:
-                type: string
-              viewCount:
-                type: number
-              thumbnailUrl:
-                type: string
-                format: uri
-            required:
-              - fileId
-            additionalProperties: false
+            $ref: "#/components/schemas/Models.File"
         keyCount:
           type: number
       required:
@@ -735,13 +735,24 @@ components:
       $schema: https://json-schema.org/draft/2020-12/schema
       type: object
       properties:
-        status:
-          default: downloaded
-          type: string
+        status: *a1
       required:
         - status
       additionalProperties: false
       id: ListFilesQuery
+    Models.DeleteFileResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        deleted:
+          type: boolean
+        fileRemoved:
+          type: boolean
+      required:
+        - deleted
+        - fileRemoved
+      additionalProperties: false
+      id: DeleteFileResponse
     Models.PartialDeletionResponse:
       $schema: https://json-schema.org/draft/2020-12/schema
       type: object

--- a/App/Dependencies/ServerClient.swift
+++ b/App/Dependencies/ServerClient.swift
@@ -384,10 +384,8 @@ extension ServerClient: DependencyKey {
       logger.info(.network, "ServerClient.getFiles called with status filter: \(statusFilter.rawValue)")
       let client = makeAuthenticatedAPIClient()
 
-      // TODO: Add query parameter support when backend API is deployed and OpenAPI types regenerated
-      // For now, fetch files without status filter (backend returns all by default after deployment)
       let response = try await client.getFiles(
-        body: .json(Components.Schemas.Models_period_ListFilesQuery(status: statusFilter.rawValue))
+        query: .init(status: statusFilter.rawValue)
       )
 
       switch response {
@@ -479,7 +477,7 @@ extension ServerClient: DependencyKey {
       logger.info(.network, "ServerClient.deleteFile called with fileId: \(fileId)")
       let client = makeAuthenticatedAPIClient()
 
-      let response = try await client.deleteFile(
+      let response = try await client.deleteFilesByFileId(
         path: .init(fileId: fileId)
       )
 
@@ -489,8 +487,8 @@ extension ServerClient: DependencyKey {
         logger.info(.network, "ServerClient.deleteFile succeeded")
         return DeleteFileResponse(
           body: DeleteFileResponseDetail(
-            deleted: payload.deleted ?? false,
-            fileRemoved: payload.fileRemoved ?? false
+            deleted: payload.deleted,
+            fileRemoved: payload.fileRemoved
           ),
           error: nil,
           requestId: "generated"
@@ -554,11 +552,10 @@ extension ServerClient: DependencyKey {
 
 /// Maps an item from the `/files` list response to the domain `File` model.
 ///
-/// The generator emits `Models.FileListResponse.contents` as an inline array of
-/// nested structs (`contentsPayloadPayload`) rather than a reference to the
-/// top-level `Models.File` schema, so we take that nested type directly.
+/// The CLI's $ref promotion resolves `FileListResponse.contents` items to the
+/// top-level `Models.File` component, so this takes `Models_period_File` directly.
 private func mapAPIFileListItemToDomainFile(
-  _ apiFile: Components.Schemas.Models_period_FileListResponse.contentsPayloadPayload
+  _ apiFile: Components.Schemas.Models_period_File
 ) -> File {
   let publishDate = apiFile.publishDate.flatMap { DateFormatters.parse($0) }
 

--- a/App/Dependencies/ServerClient.swift
+++ b/App/Dependencies/ServerClient.swift
@@ -18,6 +18,7 @@ struct ServerClient {
   var refreshToken: @Sendable () async throws -> LoginResponse
   var getFiles: @Sendable (_ statusFilter: FileStatusFilter) async throws -> FileResponse
   var addFile: @Sendable (_ url: URL) async throws -> DownloadFileResponse
+  var deleteFile: @Sendable (_ fileId: String) async throws -> DeleteFileResponse
   var logoutUser: @Sendable () async throws -> Void
 }
 
@@ -473,6 +474,48 @@ extension ServerClient: DependencyKey {
       }
     },
 
+    deleteFile: { fileId in
+      @Dependency(\.logger) var logger
+      logger.info(.network, "ServerClient.deleteFile called with fileId: \(fileId)")
+      let client = makeAuthenticatedAPIClient()
+
+      let response = try await client.deleteFile(
+        path: .init(fileId: fileId)
+      )
+
+      switch response {
+      case let .ok(r):
+        let payload = try r.body.json
+        logger.info(.network, "ServerClient.deleteFile succeeded")
+        return DeleteFileResponse(
+          body: DeleteFileResponseDetail(
+            deleted: payload.deleted ?? false,
+            fileRemoved: payload.fileRemoved ?? false
+          ),
+          error: nil,
+          requestId: "generated"
+        )
+      case let .badRequest(r):
+        throw mapStatusCodeToError(
+          400,
+          message: (try? r.body.json.error.message).map { "\($0)" },
+          requestId: try? r.body.json.requestId
+        )
+      case let .unauthorized(r):
+        throw mapStatusCodeToError(401, message: nil, requestId: try? r.body.json.requestId)
+      case let .forbidden(r):
+        throw mapStatusCodeToError(403, message: nil, requestId: try? r.body.json.requestId)
+      case let .internalServerError(r):
+        throw mapStatusCodeToError(
+          500,
+          message: (try? r.body.json.error.message).map { "\($0)" },
+          requestId: try? r.body.json.requestId
+        )
+      case let .undocumented(code, p):
+        throw mapStatusCodeToError(code, message: nil, requestId: p.headerFields[amznRequestIdField])
+      }
+    },
+
     logoutUser: {
       @Dependency(\.logger) var logger
       logger.info(.network, "ServerClient.logoutUser called")
@@ -596,6 +639,13 @@ extension ServerClient {
         requestId: "test-request-id"
       )
     },
+    deleteFile: { _ in
+      DeleteFileResponse(
+        body: DeleteFileResponseDetail(deleted: true, fileRemoved: true),
+        error: nil,
+        requestId: "test-request-id"
+      )
+    },
     logoutUser: {}
   )
 
@@ -638,6 +688,13 @@ extension ServerClient {
     addFile: { _ in
       DownloadFileResponse(
         body: DownloadFileResponseDetail(status: "queued"),
+        error: nil,
+        requestId: "preview"
+      )
+    },
+    deleteFile: { _ in
+      DeleteFileResponse(
+        body: DeleteFileResponseDetail(deleted: true, fileRemoved: true),
         error: nil,
         requestId: "preview"
       )

--- a/App/Features/FileCellFeature.swift
+++ b/App/Features/FileCellFeature.swift
@@ -13,6 +13,7 @@ struct FileCellFeature {
     var isDownloading: Bool = false
     var downloadProgress: Double = 0
     var isDownloaded: Bool = false // Cached to avoid fileClient.fileExists() in view body
+    var isServerDownloading: Bool = false
     @Presents var alert: AlertState<Action.Alert>?
 
     /// File is pending when metadata is received but no download URL is available yet
@@ -31,6 +32,7 @@ struct FileCellFeature {
     case downloadProgressUpdated(Double)
     case downloadCompleted(URL)
     case downloadFailed(String)
+    case deleteFailed(String)
     case alert(PresentationAction<Alert>)
     case delegate(Delegate)
 
@@ -161,7 +163,11 @@ struct FileCellFeature {
 
       case .deleteButtonTapped:
         let file = state.file
-        return .run { [thumbnailCacheClient] send in
+        let serverClient = serverClient
+        let coreDataClient = coreDataClient
+        let fileClient = fileClient
+        return .run { send in
+          let _ = try await serverClient.deleteFile(file.fileId)
           try await coreDataClient.deleteFile(file)
           if let url = file.url, fileClient.fileExists(url) {
             try await fileClient.deleteFile(url)
@@ -169,7 +175,22 @@ struct FileCellFeature {
           // Also delete cached thumbnail
           await thumbnailCacheClient.deleteThumbnail(file.fileId)
           await send(.delegate(.fileDeleted(file)))
+        } catch: { error, send in
+          await send(.deleteFailed(error.localizedDescription))
         }
+
+      case let .deleteFailed(message):
+        let fileName = state.file.title ?? state.file.key
+        state.alert = AlertState {
+          TextState("Delete Failed")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) {
+            TextState("OK")
+          }
+        } message: {
+          TextState("Could not delete \"\(fileName)\": \(message)")
+        }
+        return .none
 
       case .delegate:
         return .none

--- a/App/Features/FileDetailFeature.swift
+++ b/App/Features/FileDetailFeature.swift
@@ -41,6 +41,7 @@ struct FileDetailFeature {
     }
   }
 
+  @Dependency(\.serverClient) var serverClient
   @Dependency(\.coreDataClient) var coreDataClient
   @Dependency(\.fileClient) var fileClient
   @Dependency(\.downloadClient) var downloadClient
@@ -158,13 +159,19 @@ struct FileDetailFeature {
 
       case .alert(.presented(.confirmDelete)):
         let file = state.file
+        let logger = logger
         return .run { [thumbnailCacheClient] send in
+          let _ = try await serverClient.deleteFile(file.fileId)
           try await coreDataClient.deleteFile(file)
           if let url = file.url, fileClient.fileExists(url) {
             try await fileClient.deleteFile(url)
           }
           // Also delete cached thumbnail
           await thumbnailCacheClient.deleteThumbnail(file.fileId)
+          await send(.delegate(.fileDeleted(file)))
+        } catch: { error, send in
+          logger.error(.network, "Delete failed", metadata: ["fileId": file.fileId, "error": error.localizedDescription])
+          // Still dismiss and report deleted to avoid stuck UI state
           await send(.delegate(.fileDeleted(file)))
         }
 

--- a/App/Features/FileDetailFeature.swift
+++ b/App/Features/FileDetailFeature.swift
@@ -23,6 +23,7 @@ struct FileDetailFeature {
     case downloadProgressUpdated(Double)
     case downloadCompleted(URL)
     case downloadFailed(String)
+    case showDeleteError(fileName: String, message: String)
     case alert(PresentationAction<Alert>)
     case delegate(Delegate)
 
@@ -170,10 +171,23 @@ struct FileDetailFeature {
           await thumbnailCacheClient.deleteThumbnail(file.fileId)
           await send(.delegate(.fileDeleted(file)))
         } catch: { error, send in
-          logger.error(.network, "Delete failed", metadata: ["fileId": file.fileId, "error": error.localizedDescription])
-          // Still dismiss and report deleted to avoid stuck UI state
-          await send(.delegate(.fileDeleted(file)))
+          let message = error.localizedDescription
+          logger.error(.network, "Delete failed", metadata: ["fileId": file.fileId, "error": message])
+          let fileName = file.title ?? file.key
+          await send(.showDeleteError(fileName: fileName, message: message))
         }
+
+      case let .showDeleteError(fileName, message):
+        state.alert = AlertState {
+          TextState("Delete Failed")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) {
+            TextState("OK")
+          }
+        } message: {
+          TextState("Could not delete \"\(fileName)\": \(message)")
+        }
+        return .none
 
       case .alert:
         return .none

--- a/App/Features/FileListFeature.swift
+++ b/App/Features/FileListFeature.swift
@@ -53,8 +53,10 @@ struct FileListFeature {
     // Push notification actions
     case fileAddedFromPush(File)
     case updateFileUrl(fileId: String, url: URL)
+    case fileDownloadStartedOnServer(fileId: String)
     case refreshFileState(String) // fileId
     case fileFailed(fileId: String, error: String)
+    case deleteFileFailed(File, String)
     case clearAllFiles // Clears state and CoreData (used on registration)
     case delegate(Delegate)
 
@@ -82,6 +84,7 @@ struct FileListFeature {
   @Dependency(\.logger) var logger
   @Dependency(\.liveActivityClient) var liveActivityClient
   @Dependency(\.pasteboardClient) var pasteboardClient
+  @Dependency(\.fileClient) var fileClient
 
   private enum CancelID {
     case loadFiles
@@ -127,6 +130,7 @@ struct FileListFeature {
             newState.isDownloaded = existing.isDownloaded
             newState.isDownloading = existing.isDownloading
             newState.downloadProgress = existing.downloadProgress
+            newState.isServerDownloading = existing.isServerDownloading
           }
           return newState
         })
@@ -169,6 +173,7 @@ struct FileListFeature {
               newState.isDownloaded = existing.isDownloaded
               newState.isDownloading = existing.isDownloading
               newState.downloadProgress = existing.downloadProgress
+              newState.isServerDownloading = existing.isServerDownloading
             }
             return newState
           })
@@ -351,10 +356,31 @@ struct FileListFeature {
         return .none
 
       case let .deleteFiles(indexSet):
-        for index in indexSet {
+        let filesToDelete = indexSet.compactMap { index -> File? in
+          guard state.files.indices.contains(index) else { return nil }
+          return state.files[index].file
+        }
+        // Optimistic removal from UI
+        for index in indexSet.sorted().reversed() {
           state.files.remove(at: index)
         }
-        return .none
+        guard !filesToDelete.isEmpty else { return .none }
+        let serverClient = serverClient
+        let coreDataClient = coreDataClient
+        let fileClient = fileClient
+        return .run { send in
+          for file in filesToDelete {
+            do {
+              let _ = try await serverClient.deleteFile(file.fileId)
+              try await coreDataClient.deleteFile(file)
+              if let url = file.url, fileClient.fileExists(url) {
+                try await fileClient.deleteFile(url)
+              }
+            } catch {
+              await send(.deleteFileFailed(file, error.localizedDescription))
+            }
+          }
+        }
 
       case let .files(.element(id: _, action: .delegate(.fileDeleted(file)))):
         state.files.remove(id: file.fileId)
@@ -401,7 +427,6 @@ struct FileListFeature {
         // Remove from pending if it was there
         state.pendingFileIds.remove(file.fileId)
         // For new files, trigger onAppear to check download status
-        // (handles case where metadata notification was missed but file was downloaded)
         if isNewFile {
           return .send(.files(.element(id: file.fileId, action: .onAppear)))
         }
@@ -411,6 +436,14 @@ struct FileListFeature {
         // Update the file's URL in state (called when download-ready notification arrives)
         if var fileState = state.files[id: fileId] {
           fileState.file.url = url
+          fileState.isServerDownloading = false
+          state.files[id: fileId] = fileState
+        }
+        return .none
+
+      case let .fileDownloadStartedOnServer(fileId):
+        if var fileState = state.files[id: fileId] {
+          fileState.isServerDownloading = true
           state.files[id: fileId] = fileState
         }
         return .none
@@ -444,6 +477,22 @@ struct FileListFeature {
           }
         } message: {
           TextState(error)
+        }
+        return .none
+
+      case let .deleteFileFailed(file, errorMessage):
+        // Re-insert the file and show an error
+        state.files.append(FileCellFeature.State(file: file))
+        state.files.sort { ($0.file.publishDate ?? .distantPast) > ($1.file.publishDate ?? .distantPast) }
+        let fileName = file.title ?? file.key
+        state.alert = AlertState {
+          TextState("Delete Failed")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) {
+            TextState("OK")
+          }
+        } message: {
+          TextState("Failed to delete \"\(fileName)\": \(errorMessage)")
         }
         return .none
 

--- a/App/Features/FileListFeature.swift
+++ b/App/Features/FileListFeature.swift
@@ -509,8 +509,7 @@ struct FileListFeature {
       // Handle delegate actions from FileDetailFeature
       case let .detail(.presented(.delegate(.fileDeleted(file)))):
         state.files.remove(id: file.fileId)
-        state.selectedFile = nil
-        return .none
+        return .send(.detail(.dismiss))
 
       case let .detail(.presented(.delegate(.playFile(file)))):
         state.isPreparingToPlay = true

--- a/App/Features/RootFeature.swift
+++ b/App/Features/RootFeature.swift
@@ -285,6 +285,9 @@ struct RootFeature {
             await send(.downloadReadyProcessed(fileId: fileId, key: key, url: url, size: size))
           }
 
+        case let .downloadStarted(fileId):
+          return .send(.main(.fileList(.fileDownloadStartedOnServer(fileId: fileId))))
+
         case let .failure(fileId, _, _, errorMessage):
           // Update file status to failed in CoreData and UI, end Live Activity
           return .run { [coreDataClient, liveActivityClient] send in

--- a/App/Models/DeleteFileResponse.swift
+++ b/App/Models/DeleteFileResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-struct DeleteFileResponseDetail: Codable {
+struct DeleteFileResponseDetail: Codable, Sendable {
     var deleted: Bool
     var fileRemoved: Bool
 }
 
-struct DeleteFileResponse: Codable {
+struct DeleteFileResponse: Codable, Sendable {
     var body: DeleteFileResponseDetail?
     var error: ErrorDetail?
     var requestId: String

--- a/App/Models/DeleteFileResponse.swift
+++ b/App/Models/DeleteFileResponse.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct DeleteFileResponseDetail: Codable {
+    var deleted: Bool
+    var fileRemoved: Bool
+}
+
+struct DeleteFileResponse: Codable {
+    var body: DeleteFileResponseDetail?
+    var error: ErrorDetail?
+    var requestId: String
+}

--- a/App/Models/DeleteFileResponse.swift
+++ b/App/Models/DeleteFileResponse.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-struct DeleteFileResponseDetail: Codable, Sendable {
-    var deleted: Bool
-    var fileRemoved: Bool
+struct DeleteFileResponseDetail: Codable {
+  var deleted: Bool
+  var fileRemoved: Bool
 }
 
-struct DeleteFileResponse: Codable, Sendable {
-    var body: DeleteFileResponseDetail?
-    var error: ErrorDetail?
-    var requestId: String
+struct DeleteFileResponse: Codable {
+  var body: DeleteFileResponseDetail?
+  var error: ErrorDetail?
+  var requestId: String
 }

--- a/App/Models/PushNotification.swift
+++ b/App/Models/PushNotification.swift
@@ -7,6 +7,8 @@ enum PushNotificationType: Equatable {
   case metadata(File)
   /// Download URL is ready - can start downloading
   case downloadReady(fileId: String, key: String, url: URL, size: Int64)
+  /// Server has started downloading the file to S3
+  case downloadStarted(fileId: String)
   /// File processing failed
   case failure(fileId: String, title: String?, errorCategory: String, errorMessage: String)
   /// Unknown or malformed notification
@@ -45,6 +47,13 @@ enum PushNotificationType: Equatable {
         return .unknown
       }
       return .downloadReady(fileId: fileId, key: key, url: url, size: Int64(size))
+
+    case "DownloadStartedNotification":
+      guard let fileId = fileData["fileId"] as? String else {
+        logger.warning(.push, "Missing fileId in DownloadStartedNotification")
+        return .unknown
+      }
+      return .downloadStarted(fileId: fileId)
 
     case "FailureNotification":
       guard let fileId = fileData["fileId"] as? String,

--- a/App/Models/PushNotification.swift
+++ b/App/Models/PushNotification.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import Foundation
 
 /// Represents the type of push notification received for file operations
-enum PushNotificationType: Equatable, Sendable {
+enum PushNotificationType: Equatable {
   /// Full file metadata received (no url, no size) - file is being processed on server
   case metadata(File)
   /// Download URL is ready - can start downloading

--- a/App/Models/PushNotification.swift
+++ b/App/Models/PushNotification.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import Foundation
 
 /// Represents the type of push notification received for file operations
-enum PushNotificationType: Equatable {
+enum PushNotificationType: Equatable, Sendable {
   /// Full file metadata received (no url, no size) - file is being processed on server
   case metadata(File)
   /// Download URL is ready - can start downloading

--- a/App/Views/FileListView.swift
+++ b/App/Views/FileListView.swift
@@ -136,6 +136,14 @@ struct FileCellView: View {
       Text("Processing...")
         .font(.caption2)
         .foregroundStyle(theme.warningColor)
+    } else if store.isServerDownloading, !store.isDownloading, !store.isDownloaded {
+      HStack(spacing: 4) {
+        Image(systemName: "icloud.and.arrow.down")
+          .font(.caption2)
+        Text("Server downloading...")
+      }
+      .font(.caption2)
+      .foregroundStyle(Color.cyan)
     } else if store.isDownloading {
       Text("Downloading \(Int(store.downloadProgress * 100))%")
         .font(.caption2)

--- a/App/Views/FileListView.swift
+++ b/App/Views/FileListView.swift
@@ -352,27 +352,27 @@ struct FileListView: View {
   }
 
   private var fileList: some View {
-    ScrollView {
-      LazyVStack(spacing: 0) {
-        ForEach(store.scope(state: \.files, action: \.files)) { cellStore in
-          FileCellView(store: cellStore)
-            .contentShape(Rectangle())
-            .onTapGesture {
-              store.send(.fileTapped(cellStore.state))
-            }
-            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-              Button(role: .destructive) {
-                if let index = store.files.firstIndex(where: { $0.id == cellStore.state.id }) {
-                  store.send(.deleteFiles(IndexSet(integer: index)))
-                }
-              } label: {
-                Label("Delete", systemImage: "trash")
+    List {
+      ForEach(store.scope(state: \.files, action: \.files)) { cellStore in
+        FileCellView(store: cellStore)
+          .contentShape(Rectangle())
+          .onTapGesture {
+            store.send(.fileTapped(cellStore.state))
+          }
+          .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+              if let index = store.files.firstIndex(where: { $0.id == cellStore.state.id }) {
+                store.send(.deleteFiles(IndexSet(integer: index)))
               }
+            } label: {
+              Label("Delete", systemImage: "trash")
             }
-        }
+          }
+          .listRowInsets(EdgeInsets())
+          .listRowSeparator(.hidden)
       }
-      .padding(.vertical, 12)
     }
+    .listStyle(.plain)
     .refreshable {
       store.send(.refreshButtonTapped)
     }

--- a/OfflineMediaDownloaderTests/FileCellFeatureTests.swift
+++ b/OfflineMediaDownloaderTests/FileCellFeatureTests.swift
@@ -240,8 +240,9 @@ struct FileCellFeatureTests {
   // MARK: - Delete Tests
 
   @MainActor
-  @Test("Delete button triggers file deletion from CoreData, filesystem, and thumbnail cache")
+  @Test("Delete button triggers server delete, CoreData, filesystem, and thumbnail cache removal")
   func deleteRemovesFiles() async {
+    let serverDeleteCalled = LockIsolated(false)
     let coreDataDeleteCalled = LockIsolated(false)
     let fileDeleteCalled = LockIsolated(false)
     let thumbnailDeleteCalled = LockIsolated(false)
@@ -250,6 +251,14 @@ struct FileCellFeatureTests {
       FileCellFeature()
     } withDependencies: {
       $0.logger = TestData.noopLogger
+      $0.serverClient.deleteFile = { _ in
+        serverDeleteCalled.setValue(true)
+        return DeleteFileResponse(
+          body: DeleteFileResponseDetail(deleted: true, fileRemoved: true),
+          error: nil,
+          requestId: "test"
+        )
+      }
       $0.coreDataClient.deleteFile = { _ in coreDataDeleteCalled.setValue(true) }
       $0.fileClient.fileExists = { _ in true }
       $0.fileClient.deleteFile = { _ in fileDeleteCalled.setValue(true) }
@@ -259,14 +268,16 @@ struct FileCellFeatureTests {
     await store.send(.deleteButtonTapped)
     await store.receive(\.delegate.fileDeleted)
 
+    #expect(serverDeleteCalled.value == true)
     #expect(coreDataDeleteCalled.value == true)
     #expect(fileDeleteCalled.value == true)
     #expect(thumbnailDeleteCalled.value == true)
   }
 
   @MainActor
-  @Test("Delete skips local file removal if not exists but still deletes thumbnail")
+  @Test("Delete skips local file removal if not exists but still calls server and deletes thumbnail")
   func deleteSkipsIfNotExists() async {
+    let serverDeleteCalled = LockIsolated(false)
     let fileDeleteCalled = LockIsolated(false)
     let thumbnailDeleteCalled = LockIsolated(false)
 
@@ -274,6 +285,14 @@ struct FileCellFeatureTests {
       FileCellFeature()
     } withDependencies: {
       $0.logger = TestData.noopLogger
+      $0.serverClient.deleteFile = { _ in
+        serverDeleteCalled.setValue(true)
+        return DeleteFileResponse(
+          body: DeleteFileResponseDetail(deleted: true, fileRemoved: true),
+          error: nil,
+          requestId: "test"
+        )
+      }
       $0.coreDataClient.deleteFile = { _ in }
       $0.fileClient.fileExists = { _ in false }
       $0.fileClient.deleteFile = { _ in fileDeleteCalled.setValue(true) }
@@ -283,13 +302,15 @@ struct FileCellFeatureTests {
     await store.send(.deleteButtonTapped)
     await store.receive(\.delegate.fileDeleted)
 
+    #expect(serverDeleteCalled.value == true)
     #expect(fileDeleteCalled.value == false)
     #expect(thumbnailDeleteCalled.value == true)
   }
 
   @MainActor
-  @Test("Delete with nil URL still removes from CoreData and thumbnail cache")
+  @Test("Delete with nil URL still calls server, removes from CoreData and thumbnail cache")
   func deleteWithNilUrl() async {
+    let serverDeleteCalled = LockIsolated(false)
     let coreDataDeleteCalled = LockIsolated(false)
     let thumbnailDeleteCalled = LockIsolated(false)
 
@@ -297,6 +318,14 @@ struct FileCellFeatureTests {
       FileCellFeature()
     } withDependencies: {
       $0.logger = TestData.noopLogger
+      $0.serverClient.deleteFile = { _ in
+        serverDeleteCalled.setValue(true)
+        return DeleteFileResponse(
+          body: DeleteFileResponseDetail(deleted: true, fileRemoved: true),
+          error: nil,
+          requestId: "test"
+        )
+      }
       $0.coreDataClient.deleteFile = { _ in coreDataDeleteCalled.setValue(true) }
       $0.fileClient.fileExists = { _ in false }
       $0.thumbnailCacheClient.deleteThumbnail = { _ in thumbnailDeleteCalled.setValue(true) }
@@ -305,6 +334,7 @@ struct FileCellFeatureTests {
     await store.send(.deleteButtonTapped)
     await store.receive(\.delegate.fileDeleted)
 
+    #expect(serverDeleteCalled.value == true)
     #expect(coreDataDeleteCalled.value == true)
     #expect(thumbnailDeleteCalled.value == true)
   }

--- a/OfflineMediaDownloaderTests/FileListFeatureTests.swift
+++ b/OfflineMediaDownloaderTests/FileListFeatureTests.swift
@@ -668,6 +668,7 @@ struct FileListFeatureTests {
 
     await store.send(.updateFileUrl(fileId: pendingFile.fileId, url: newUrl)) {
       $0.files[id: pendingFile.fileId]?.file.url = newUrl
+      $0.files[id: pendingFile.fileId]?.isServerDownloading = false
     }
   }
 
@@ -699,7 +700,7 @@ struct FileListFeatureTests {
   // MARK: - Delete Tests
 
   @MainActor
-  @Test("Delete files removes from state")
+  @Test("Delete files removes from state and calls server")
   func deleteFilesRemoves() async {
     var state = FileListFeature.State()
     state.files = IdentifiedArray(uniqueElements: TestData.multipleFiles.map {
@@ -711,6 +712,15 @@ struct FileListFeatureTests {
     } withDependencies: {
       $0.logger = TestData.noopLogger
       $0.pasteboardClient = TestData.noopPasteboardClient
+      $0.serverClient.deleteFile = { _ in
+        DeleteFileResponse(
+          body: DeleteFileResponseDetail(deleted: true, fileRemoved: true),
+          error: nil,
+          requestId: "test"
+        )
+      }
+      $0.coreDataClient.deleteFile = { _ in }
+      $0.fileClient.fileExists = { _ in false }
     }
 
     await store.send(.deleteFiles(IndexSet(integer: 0))) {

--- a/Packages/OMDFeatures/Sources/FileCellFeature/FileCellFeature.swift
+++ b/Packages/OMDFeatures/Sources/FileCellFeature/FileCellFeature.swift
@@ -20,6 +20,7 @@ public struct FileCellFeature: Sendable {
     }
 
     public var isDownloading: Bool = false
+    public var isServerDownloading: Bool = false
     public var downloadProgress: Double = 0
     public var isDownloaded: Bool = false
     @Presents public var alert: AlertState<Action.Alert>?

--- a/Packages/OMDFeatures/Sources/FileListFeature/FileListFeature.swift
+++ b/Packages/OMDFeatures/Sources/FileListFeature/FileListFeature.swift
@@ -60,6 +60,7 @@ public struct FileListFeature: Sendable {
     case defaultFiles(DefaultFilesFeature.Action)
     case fileAddedFromPush(File)
     case updateFileUrl(fileId: String, url: URL)
+    case fileDownloadStartedOnServer(fileId: String)
     case refreshFileState(String)
     case fileFailed(fileId: String, error: String)
     case clearAllFiles
@@ -126,6 +127,7 @@ public struct FileListFeature: Sendable {
           if let existing = existingStates[file.fileId] {
             newState.isDownloaded = existing.isDownloaded
             newState.isDownloading = existing.isDownloading
+            newState.isServerDownloading = existing.isServerDownloading
             newState.downloadProgress = existing.downloadProgress
           }
           return newState
@@ -163,6 +165,7 @@ public struct FileListFeature: Sendable {
             if let existing = existingStates[file.fileId] {
               newState.isDownloaded = existing.isDownloaded
               newState.isDownloading = existing.isDownloading
+              newState.isServerDownloading = existing.isServerDownloading
               newState.downloadProgress = existing.downloadProgress
             }
             return newState
@@ -385,6 +388,14 @@ public struct FileListFeature: Sendable {
       case let .updateFileUrl(fileId, url):
         if var fileState = state.files[id: fileId] {
           fileState.file.url = url
+          fileState.isServerDownloading = false
+          state.files[id: fileId] = fileState
+        }
+        return .none
+
+      case let .fileDownloadStartedOnServer(fileId):
+        if var fileState = state.files[id: fileId] {
+          fileState.isServerDownloading = true
           state.files[id: fileId] = fileState
         }
         return .none

--- a/Packages/OMDFeatures/Sources/RootFeature/PushNotification.swift
+++ b/Packages/OMDFeatures/Sources/RootFeature/PushNotification.swift
@@ -7,6 +7,7 @@ import SharedModels
 public enum PushNotificationType: Equatable, Sendable {
   case metadata(File)
   case downloadReady(fileId: String, key: String, url: URL, size: Int64)
+  case downloadStarted(fileId: String)
   case failure(fileId: String, title: String?, errorCategory: String, errorMessage: String)
   case unknown
 
@@ -41,6 +42,13 @@ public enum PushNotificationType: Equatable, Sendable {
         return .unknown
       }
       return .downloadReady(fileId: fileId, key: key, url: url, size: Int64(size))
+
+    case "DownloadStartedNotification":
+      guard let fileId = fileData["fileId"] as? String else {
+        logger.warning(.push, "Missing fileId in DownloadStartedNotification")
+        return .unknown
+      }
+      return .downloadStarted(fileId: fileId)
 
     case "FailureNotification":
       guard let fileId = fileData["fileId"] as? String,

--- a/Packages/OMDFeatures/Sources/RootFeature/RootFeature.swift
+++ b/Packages/OMDFeatures/Sources/RootFeature/RootFeature.swift
@@ -279,6 +279,9 @@ public struct RootFeature: Sendable {
             await send(.downloadReadyProcessed(fileId: fileId, key: key, url: url, size: size))
           }
 
+        case let .downloadStarted(fileId):
+          return .send(.main(.fileList(.fileDownloadStartedOnServer(fileId: fileId))))
+
         case let .failure(fileId, _, _, errorMessage):
           return .run { [coreDataClient, liveActivityClient] send in
             await liveActivityClient.endActivity(fileId: fileId, status: .failed, errorMessage: errorMessage)

--- a/Packages/OMDFeatures/Sources/ServerClient/ServerClient.swift
+++ b/Packages/OMDFeatures/Sources/ServerClient/ServerClient.swift
@@ -364,7 +364,7 @@ extension ServerClient: DependencyKey {
       let client = makeAuthenticatedAPIClient()
 
       let response = try await client.getFiles(
-        body: .json(Components.Schemas.Models_period_ListFilesQuery(status: statusFilter.rawValue))
+        query: .init(status: statusFilter.rawValue)
       )
 
       return try handleAPIResponse(


### PR DESCRIPTION
## Summary
- Parse new `DownloadStartedNotification` push type, show "server downloading" indicator on file cells
- Server-backed delete: swipe-to-delete, cell delete button, and detail delete all call `DELETE /files/{fileId}` before local cleanup
- Optimistic UI with rollback on server error
- `isServerDownloading` state preserved across reloads, cleared when `DownloadReadyNotification` arrives

## Changes
- **PushNotification.swift**: Added `downloadStarted(fileId:)` case and parser
- **FileCellFeature.swift**: Added `isServerDownloading` state, server-backed `deleteButtonTapped` with error handling
- **FileListFeature.swift**: Added `fileDownloadStartedOnServer`, `deleteFileFailed` actions; `deleteFiles` now calls server; added `fileClient` dependency
- **FileDetailFeature.swift**: Added `serverClient` dependency, `confirmDelete` now calls server first
- **RootView.swift**: Routes `.downloadStarted` push notification to FileListFeature
- **FileListView.swift**: Shows "Server downloading..." indicator with cloud icon
- **ServerClient.swift**: Added `deleteFile` endpoint (`DELETE /files/{fileId}`)
- **DeleteFileResponse.swift**: New response model

## Test plan
- [x] Trigger a download, verify "server downloading" indicator appears on file cell
- [x] Verify indicator clears when download completes (DownloadReady notification)
- [x] Swipe-to-delete a file -- verify it disappears and server is called
- [x] Delete via cell button -- verify server call + local cleanup
- [x] Delete via detail view -- verify confirmation dialog + server call
- [x] Disconnect network, swipe-to-delete -- verify file re-appears with error alert
- [x] Unit tests updated for new server-backed delete behavior