### PR TITLE
chore(openapi): sync spec with delete endpoint and fix query param shape

### DIFF
--- a/APITypes/Sources/APITypes/openapi.yaml
+++ b/APITypes/Sources/APITypes/openapi.yaml
@@ -135,12 +135,53 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Models.InternalServerError"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Models.ListFilesQuery"
+      parameters:
+        - name: status
+          in: query
+          required: true
+          schema: &a1
+            default: downloaded
+            type: string
+  /files/{fileId}:
+    delete:
+      operationId: deleteFilesByFileId
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.DeleteFileResponse"
+        "400":
+          description: Bad request - validation failed or invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "401":
+          description: Unauthorized - authentication required or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.UnauthorizedError"
+        "403":
+          description: Forbidden - authenticated but not authorized for this resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ForbiddenError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.InternalServerError"
+      parameters:
+        - name: fileId
+          in: path
+          required: true
+          schema:
+            type: string
   /user:
     delete:
       operationId: deleteUser
@@ -442,48 +483,7 @@ components:
         contents:
           type: array
           items:
-            type: object
-            properties:
-              fileId:
-                type: string
-              key:
-                type: string
-              size:
-                type: number
-              status:
-                type: string
-                enum:
-                  - Queued
-                  - Downloading
-                  - Downloaded
-                  - Failed
-              title:
-                type: string
-              publishDate:
-                type: string
-              authorName:
-                type: string
-              authorUser:
-                type: string
-              contentType:
-                type: string
-              description:
-                type: string
-              url:
-                type: string
-                format: uri
-              duration:
-                type: number
-              uploadDate:
-                type: string
-              viewCount:
-                type: number
-              thumbnailUrl:
-                type: string
-                format: uri
-            required:
-              - fileId
-            additionalProperties: false
+            $ref: "#/components/schemas/Models.File"
         keyCount:
           type: number
       required:
@@ -735,13 +735,24 @@ components:
       $schema: https://json-schema.org/draft/2020-12/schema
       type: object
       properties:
-        status:
-          default: downloaded
-          type: string
+        status: *a1
       required:
         - status
       additionalProperties: false
       id: ListFilesQuery
+    Models.DeleteFileResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        deleted:
+          type: boolean
+        fileRemoved:
+          type: boolean
+      required:
+        - deleted
+        - fileRemoved
+      additionalProperties: false
+      id: DeleteFileResponse
     Models.PartialDeletionResponse:
       $schema: https://json-schema.org/draft/2020-12/schema
       type: object

--- a/App/Dependencies/ServerClient.swift
+++ b/App/Dependencies/ServerClient.swift
@@ -383,10 +383,8 @@ extension ServerClient: DependencyKey {
       logger.info(.network, "ServerClient.getFiles called with status filter: \(statusFilter.rawValue)")
       let client = makeAuthenticatedAPIClient()
 
-      // TODO: Add query parameter support when backend API is deployed and OpenAPI types regenerated
-      // For now, fetch files without status filter (backend returns all by default after deployment)
       let response = try await client.getFiles(
-        body: .json(Components.Schemas.Models_period_ListFilesQuery(status: statusFilter.rawValue))
+        query: .init(status: statusFilter.rawValue)
       )
 
       switch response {
@@ -511,11 +509,10 @@ extension ServerClient: DependencyKey {
 
 /// Maps an item from the `/files` list response to the domain `File` model.
 ///
-/// The generator emits `Models.FileListResponse.contents` as an inline array of
-/// nested structs (`contentsPayloadPayload`) rather than a reference to the
-/// top-level `Models.File` schema, so we take that nested type directly.
+/// The CLI's $ref promotion resolves `FileListResponse.contents` items to the
+/// top-level `Models.File` component, so this takes `Models_period_File` directly.
 private func mapAPIFileListItemToDomainFile(
-  _ apiFile: Components.Schemas.Models_period_FileListResponse.contentsPayloadPayload
+  _ apiFile: Components.Schemas.Models_period_File
 ) -> File {
   let publishDate = apiFile.publishDate.flatMap { DateFormatters.parse($0) }
 

--- a/Packages/OMDFeatures/Sources/ServerClient/ServerClient.swift
+++ b/Packages/OMDFeatures/Sources/ServerClient/ServerClient.swift
@@ -364,7 +364,7 @@ extension ServerClient: DependencyKey {
       let client = makeAuthenticatedAPIClient()
 
       let response = try await client.getFiles(
-        body: .json(Components.Schemas.Models_period_ListFilesQuery(status: statusFilter.rawValue))
+        query: .init(status: statusFilter.rawValue)
       )
 
       return try handleAPIResponse(


### PR DESCRIPTION
Syncs OpenAPI spec from mantle-OMD feat branch. New DELETE /files/{fileId} endpoint. Fixes getFiles to use query params (not body) and FileListResponse mapper to use top-level Models.File (not inline contentsPayloadPayload) per mantle#51 changes. Xcode build green. Depends on mantle-OfflineMediaDownloader#471.