### PR TITLE
feat(ios): download notifications, Live Activity, thumbnail caching

### DIFF
--- a/APITypes/Sources/APITypes/openapi.yaml
+++ b/APITypes/Sources/APITypes/openapi.yaml
@@ -7,8 +7,9 @@ paths:
     post:
       operationId: postDeviceEvent
       responses:
-        "200":
+        "200": &a1
           description: Successful response
+        "204": *a1
         "400":
           description: Bad request - validation failed or invalid input
           content:
@@ -25,30 +26,19 @@ paths:
     post:
       operationId: postDeviceRegister
       responses:
-        "200":
+        "200": &a2
           description: Successful response
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Models.DeviceRegistrationResponse"
+        "201": *a2
         "400":
           description: Bad request - validation failed or invalid input
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Models.ErrorResponse"
-        "401":
-          description: Unauthorized - authentication required or invalid
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Models.UnauthorizedError"
-        "403":
-          description: Forbidden - authenticated but not authorized for this resource
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Models.ForbiddenError"
         "500":
           description: Internal server error
           content:
@@ -65,12 +55,13 @@ paths:
     post:
       operationId: postFeedlyWebhook
       responses:
-        "200":
+        "200": &a3
           description: Successful response
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Models.WebhookResponse"
+        "202": *a3
         "400":
           description: Bad request - validation failed or invalid input
           content:
@@ -117,18 +108,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Models.ErrorResponse"
-        "401":
-          description: Unauthorized - authentication required or invalid
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Models.UnauthorizedError"
-        "403":
-          description: Forbidden - authenticated but not authorized for this resource
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Models.ForbiddenError"
         "500":
           description: Internal server error
           content:
@@ -139,7 +118,7 @@ paths:
         - name: status
           in: query
           required: true
-          schema: &a1
+          schema: &a7
             default: downloaded
             type: string
   /files/{fileId}:
@@ -186,12 +165,14 @@ paths:
     delete:
       operationId: deleteUser
       responses:
-        "200":
+        "200": &a4
           description: Successful response
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Models.PartialDeletionResponse"
+        "204": *a4
+        "207": *a4
         "400":
           description: Bad request - validation failed or invalid input
           content:
@@ -248,8 +229,9 @@ paths:
     post:
       operationId: postUserLogout
       responses:
-        "200":
+        "200": &a5
           description: Successful response
+        "204": *a5
         "400":
           description: Bad request - validation failed or invalid input
           content:
@@ -340,12 +322,13 @@ paths:
     post:
       operationId: postUserSubscribe
       responses:
-        "200":
+        "200": &a6
           description: Successful response
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Models.SubscriptionResponse"
+        "201": *a6
         "400":
           description: Bad request - validation failed or invalid input
           content:
@@ -735,7 +718,7 @@ components:
       $schema: https://json-schema.org/draft/2020-12/schema
       type: object
       properties:
-        status: *a1
+        status: *a7
       required:
         - status
       additionalProperties: false

--- a/APITypes/Sources/APITypes/openapi.yaml
+++ b/APITypes/Sources/APITypes/openapi.yaml
@@ -135,12 +135,53 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Models.InternalServerError"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Models.ListFilesQuery"
+      parameters:
+        - name: status
+          in: query
+          required: true
+          schema: &a1
+            default: downloaded
+            type: string
+  /files/{fileId}:
+    delete:
+      operationId: deleteFilesByFileId
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.DeleteFileResponse"
+        "400":
+          description: Bad request - validation failed or invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ErrorResponse"
+        "401":
+          description: Unauthorized - authentication required or invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.UnauthorizedError"
+        "403":
+          description: Forbidden - authenticated but not authorized for this resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.ForbiddenError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Models.InternalServerError"
+      parameters:
+        - name: fileId
+          in: path
+          required: true
+          schema:
+            type: string
   /user:
     delete:
       operationId: deleteUser
@@ -442,48 +483,7 @@ components:
         contents:
           type: array
           items:
-            type: object
-            properties:
-              fileId:
-                type: string
-              key:
-                type: string
-              size:
-                type: number
-              status:
-                type: string
-                enum:
-                  - Queued
-                  - Downloading
-                  - Downloaded
-                  - Failed
-              title:
-                type: string
-              publishDate:
-                type: string
-              authorName:
-                type: string
-              authorUser:
-                type: string
-              contentType:
-                type: string
-              description:
-                type: string
-              url:
-                type: string
-                format: uri
-              duration:
-                type: number
-              uploadDate:
-                type: string
-              viewCount:
-                type: number
-              thumbnailUrl:
-                type: string
-                format: uri
-            required:
-              - fileId
-            additionalProperties: false
+            $ref: "#/components/schemas/Models.File"
         keyCount:
           type: number
       required:
@@ -735,13 +735,24 @@ components:
       $schema: https://json-schema.org/draft/2020-12/schema
       type: object
       properties:
-        status:
-          default: downloaded
-          type: string
+        status: *a1
       required:
         - status
       additionalProperties: false
       id: ListFilesQuery
+    Models.DeleteFileResponse:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        deleted:
+          type: boolean
+        fileRemoved:
+          type: boolean
+      required:
+        - deleted
+        - fileRemoved
+      additionalProperties: false
+      id: DeleteFileResponse
     Models.PartialDeletionResponse:
       $schema: https://json-schema.org/draft/2020-12/schema
       type: object

--- a/App/Dependencies/ServerClient.swift
+++ b/App/Dependencies/ServerClient.swift
@@ -384,10 +384,8 @@ extension ServerClient: DependencyKey {
       logger.info(.network, "ServerClient.getFiles called with status filter: \(statusFilter.rawValue)")
       let client = makeAuthenticatedAPIClient()
 
-      // TODO: Add query parameter support when backend API is deployed and OpenAPI types regenerated
-      // For now, fetch files without status filter (backend returns all by default after deployment)
       let response = try await client.getFiles(
-        body: .json(Components.Schemas.Models_period_ListFilesQuery(status: statusFilter.rawValue))
+        query: .init(status: statusFilter.rawValue)
       )
 
       switch response {
@@ -479,7 +477,7 @@ extension ServerClient: DependencyKey {
       logger.info(.network, "ServerClient.deleteFile called with fileId: \(fileId)")
       let client = makeAuthenticatedAPIClient()
 
-      let response = try await client.deleteFile(
+      let response = try await client.deleteFilesByFileId(
         path: .init(fileId: fileId)
       )
 
@@ -489,8 +487,8 @@ extension ServerClient: DependencyKey {
         logger.info(.network, "ServerClient.deleteFile succeeded")
         return DeleteFileResponse(
           body: DeleteFileResponseDetail(
-            deleted: payload.deleted ?? false,
-            fileRemoved: payload.fileRemoved ?? false
+            deleted: payload.deleted,
+            fileRemoved: payload.fileRemoved
           ),
           error: nil,
           requestId: "generated"
@@ -554,11 +552,10 @@ extension ServerClient: DependencyKey {
 
 /// Maps an item from the `/files` list response to the domain `File` model.
 ///
-/// The generator emits `Models.FileListResponse.contents` as an inline array of
-/// nested structs (`contentsPayloadPayload`) rather than a reference to the
-/// top-level `Models.File` schema, so we take that nested type directly.
+/// The CLI's $ref promotion resolves `FileListResponse.contents` items to the
+/// top-level `Models.File` component, so this takes `Models_period_File` directly.
 private func mapAPIFileListItemToDomainFile(
-  _ apiFile: Components.Schemas.Models_period_FileListResponse.contentsPayloadPayload
+  _ apiFile: Components.Schemas.Models_period_File
 ) -> File {
   let publishDate = apiFile.publishDate.flatMap { DateFormatters.parse($0) }
 

--- a/App/Dependencies/ServerClient.swift
+++ b/App/Dependencies/ServerClient.swift
@@ -218,16 +218,20 @@ extension ServerClient: DependencyKey {
           error: nil,
           requestId: "generated"
         )
+      case let .created(r):
+        let payload = try r.body.json
+        logger.info(.network, "ServerClient.registerDevice created (201)")
+        return RegisterDeviceResponse(
+          body: EndpointResponse(endpointArn: payload.endpointArn),
+          error: nil,
+          requestId: "generated"
+        )
       case let .badRequest(r):
         throw mapStatusCodeToError(
           400,
           message: (try? r.body.json.error.message).map { "\($0)" },
           requestId: try? r.body.json.requestId
         )
-      case let .unauthorized(r):
-        throw mapStatusCodeToError(401, message: nil, requestId: try? r.body.json.requestId)
-      case let .forbidden(r):
-        throw mapStatusCodeToError(403, message: nil, requestId: try? r.body.json.requestId)
       case let .internalServerError(r):
         throw mapStatusCodeToError(
           500,
@@ -404,10 +408,6 @@ extension ServerClient: DependencyKey {
           message: (try? r.body.json.error.message).map { "\($0)" },
           requestId: try? r.body.json.requestId
         )
-      case let .unauthorized(r):
-        throw mapStatusCodeToError(401, message: nil, requestId: try? r.body.json.requestId)
-      case let .forbidden(r):
-        throw mapStatusCodeToError(403, message: nil, requestId: try? r.body.json.requestId)
       case let .internalServerError(r):
         throw mapStatusCodeToError(
           500,
@@ -446,6 +446,18 @@ extension ServerClient: DependencyKey {
           ?? payload.status.value2?.rawValue
           ?? payload.status.value3?.rawValue
           ?? "unknown"
+        return DownloadFileResponse(
+          body: DownloadFileResponseDetail(status: statusString),
+          error: nil,
+          requestId: "generated"
+        )
+      case let .accepted(r):
+        let payload = try r.body.json
+        logger.info(.network, "ServerClient.addFile accepted (202)")
+        let statusString = payload.status.value1?.rawValue
+          ?? payload.status.value2?.rawValue
+          ?? payload.status.value3?.rawValue
+          ?? "Accepted"
         return DownloadFileResponse(
           body: DownloadFileResponseDetail(status: statusString),
           error: nil,
@@ -524,6 +536,9 @@ extension ServerClient: DependencyKey {
       switch response {
       case .ok:
         logger.info(.network, "ServerClient.logoutUser succeeded")
+        return
+      case .noContent:
+        logger.info(.network, "ServerClient.logoutUser succeeded (204)")
         return
       case let .badRequest(r):
         throw mapStatusCodeToError(

--- a/App/Dependencies/ServerClient.swift
+++ b/App/Dependencies/ServerClient.swift
@@ -18,6 +18,7 @@ struct ServerClient {
   var refreshToken: @Sendable () async throws -> LoginResponse
   var getFiles: @Sendable (_ statusFilter: FileStatusFilter) async throws -> FileResponse
   var addFile: @Sendable (_ url: URL) async throws -> DownloadFileResponse
+  var deleteFile: @Sendable (_ fileId: String) async throws -> DeleteFileResponse
   var logoutUser: @Sendable () async throws -> Void
 }
 
@@ -473,6 +474,48 @@ extension ServerClient: DependencyKey {
       }
     },
 
+    deleteFile: { fileId in
+      @Dependency(\.logger) var logger
+      logger.info(.network, "ServerClient.deleteFile called with fileId: \(fileId)")
+      let client = makeAuthenticatedAPIClient()
+
+      let response = try await client.deleteFile(
+        path: .init(fileId: fileId)
+      )
+
+      switch response {
+      case let .ok(r):
+        let payload = try r.body.json
+        logger.info(.network, "ServerClient.deleteFile succeeded")
+        return DeleteFileResponse(
+          body: DeleteFileResponseDetail(
+            deleted: payload.deleted ?? false,
+            fileRemoved: payload.fileRemoved ?? false
+          ),
+          error: nil,
+          requestId: "generated"
+        )
+      case let .badRequest(r):
+        throw mapStatusCodeToError(
+          400,
+          message: (try? r.body.json.error.message).map { "\($0)" },
+          requestId: try? r.body.json.requestId
+        )
+      case let .unauthorized(r):
+        throw mapStatusCodeToError(401, message: nil, requestId: try? r.body.json.requestId)
+      case let .forbidden(r):
+        throw mapStatusCodeToError(403, message: nil, requestId: try? r.body.json.requestId)
+      case let .internalServerError(r):
+        throw mapStatusCodeToError(
+          500,
+          message: (try? r.body.json.error.message).map { "\($0)" },
+          requestId: try? r.body.json.requestId
+        )
+      case let .undocumented(code, p):
+        throw mapStatusCodeToError(code, message: nil, requestId: p.headerFields[amznRequestIdField])
+      }
+    },
+
     logoutUser: {
       @Dependency(\.logger) var logger
       logger.info(.network, "ServerClient.logoutUser called")
@@ -596,6 +639,13 @@ extension ServerClient {
         requestId: "test-request-id"
       )
     },
+    deleteFile: { _ in
+      DeleteFileResponse(
+        body: DeleteFileResponseDetail(deleted: true, fileRemoved: true),
+        error: nil,
+        requestId: "test-request-id"
+      )
+    },
     logoutUser: {}
   )
 
@@ -638,6 +688,13 @@ extension ServerClient {
     addFile: { _ in
       DownloadFileResponse(
         body: DownloadFileResponseDetail(status: "queued"),
+        error: nil,
+        requestId: "preview"
+      )
+    },
+    deleteFile: { _ in
+      DeleteFileResponse(
+        body: DeleteFileResponseDetail(deleted: true, fileRemoved: true),
         error: nil,
         requestId: "preview"
       )

--- a/App/Dependencies/ThumbnailCacheClient.swift
+++ b/App/Dependencies/ThumbnailCacheClient.swift
@@ -1,17 +1,19 @@
 import ComposableArchitecture
 import UIKit
 
-/// Client for caching thumbnail images to disk
+/// Client for caching thumbnail images with two-tier cache (memory + disk)
 @DependencyClient
 struct ThumbnailCacheClient {
   /// Get thumbnail for a file, fetching from network if not cached
   var getThumbnail: @Sendable (_ fileId: String, _ url: URL) async -> UIImage?
-  /// Check if thumbnail exists in cache
-  var hasCachedThumbnail: @Sendable (_ fileId: String) -> Bool = { _ in false }
+  /// Check if thumbnail exists in cache (memory or disk)
+  var hasCachedThumbnail: @Sendable (_ fileId: String) async -> Bool = { _ in false }
   /// Delete cached thumbnail for a file
   var deleteThumbnail: @Sendable (_ fileId: String) async -> Void
   /// Clear all cached thumbnails
   var clearCache: @Sendable () async -> Void
+  /// Pre-fetch and cache thumbnails in background (fire-and-forget from reducers)
+  var prefetchThumbnails: @Sendable (_ thumbnails: [(fileId: String, url: URL)]) async -> Void
 }
 
 extension DependencyValues {
@@ -26,56 +28,19 @@ extension DependencyValues {
 extension ThumbnailCacheClient: DependencyKey {
   static let liveValue = ThumbnailCacheClient(
     getThumbnail: { fileId, url in
-      let fileManager = FileManager.default
-      guard let cacheDir = thumbnailCacheDirectory() else { return nil }
-
-      let cachedPath = cacheDir.appendingPathComponent("\(fileId).jpg")
-
-      // Check if cached
-      if fileManager.fileExists(atPath: cachedPath.path) {
-        if let data = try? Data(contentsOf: cachedPath),
-           let image = UIImage(data: data)
-        {
-          return image
-        }
-      }
-
-      // Fetch from network
-      do {
-        let (data, response) = try await URLSession.shared.data(from: url)
-
-        guard let httpResponse = response as? HTTPURLResponse,
-              httpResponse.statusCode == 200,
-              let image = UIImage(data: data)
-        else {
-          return nil
-        }
-
-        // Save to cache (use JPEG for smaller file size)
-        if let jpegData = image.jpegData(compressionQuality: 0.8) {
-          try? jpegData.write(to: cachedPath)
-        }
-
-        return image
-      } catch {
-        return nil
-      }
+      await ThumbnailCacheStorage.shared.getImage(fileId: fileId, url: url)
     },
     hasCachedThumbnail: { fileId in
-      guard let cacheDir = thumbnailCacheDirectory() else { return false }
-      let cachedPath = cacheDir.appendingPathComponent("\(fileId).jpg")
-      return FileManager.default.fileExists(atPath: cachedPath.path)
+      await ThumbnailCacheStorage.shared.hasCached(fileId: fileId)
     },
     deleteThumbnail: { fileId in
-      guard let cacheDir = thumbnailCacheDirectory() else { return }
-      let cachedPath = cacheDir.appendingPathComponent("\(fileId).jpg")
-      try? FileManager.default.removeItem(at: cachedPath)
+      await ThumbnailCacheStorage.shared.delete(fileId: fileId)
     },
     clearCache: {
-      guard let cacheDir = thumbnailCacheDirectory() else { return }
-      try? FileManager.default.removeItem(at: cacheDir)
-      // Recreate empty directory
-      try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+      await ThumbnailCacheStorage.shared.clearAll()
+    },
+    prefetchThumbnails: { thumbnails in
+      await ThumbnailCacheStorage.shared.prefetch(thumbnails: thumbnails)
     }
   )
 }
@@ -87,29 +52,159 @@ extension ThumbnailCacheClient {
     getThumbnail: { _, _ in nil },
     hasCachedThumbnail: { _ in false },
     deleteThumbnail: { _ in },
-    clearCache: {}
+    clearCache: {},
+    prefetchThumbnails: { _ in }
   )
 
   static let previewValue = ThumbnailCacheClient(
     getThumbnail: { _, _ in nil },
     hasCachedThumbnail: { _ in false },
     deleteThumbnail: { _ in },
-    clearCache: {}
+    clearCache: {},
+    prefetchThumbnails: { _ in }
   )
 }
 
-// MARK: - Helpers
+// MARK: - Two-Tier Cache Storage Actor
 
-private func thumbnailCacheDirectory() -> URL? {
-  guard let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-    return nil
+private actor ThumbnailCacheStorage {
+  static let shared = ThumbnailCacheStorage()
+
+  // SAFETY: NSCache is thread-safe internally; actor isolation provides additional safety for access patterns
+  private let memoryCache: NSCache<NSString, UIImage> = {
+    let cache = NSCache<NSString, UIImage>()
+    cache.countLimit = 100
+    cache.totalCostLimit = 50 * 1024 * 1024 // 50MB decoded images
+    return cache
+  }()
+
+  private var inflightTasks: [String: Task<UIImage?, Never>] = [:]
+
+  init() {
+    Self.cleanupOldDirectory()
   }
-  let cacheDir = documentsDir.appendingPathComponent("thumbnails", isDirectory: true)
 
-  // Create directory if needed
-  if !FileManager.default.fileExists(atPath: cacheDir.path) {
-    try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+  // MARK: - Public API
+
+  func getImage(fileId: String, url: URL) async -> UIImage? {
+    // Tier 1: Memory cache (instant)
+    if let cached = memoryCache.object(forKey: fileId as NSString) {
+      return cached
+    }
+
+    // Deduplicate in-flight requests
+    if let existingTask = inflightTasks[fileId] {
+      return await existingTask.value
+    }
+
+    // Tier 2: Disk cache
+    if let diskImage = loadFromDisk(fileId: fileId) {
+      memoryCache.setObject(diskImage, forKey: fileId as NSString)
+      return diskImage
+    }
+
+    // Tier 3: Network fetch with deduplication
+    let task = Task<UIImage?, Never> {
+      do {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200,
+              let image = UIImage(data: data)
+        else { return nil }
+
+        saveToDisk(fileId: fileId, image: image)
+        memoryCache.setObject(image, forKey: fileId as NSString)
+        return image
+      } catch {
+        return nil
+      }
+    }
+
+    inflightTasks[fileId] = task
+    let result = await task.value
+    inflightTasks[fileId] = nil
+    return result
   }
 
-  return cacheDir
+  func hasCached(fileId: String) -> Bool {
+    if memoryCache.object(forKey: fileId as NSString) != nil { return true }
+    return diskFileExists(fileId: fileId)
+  }
+
+  func delete(fileId: String) {
+    memoryCache.removeObject(forKey: fileId as NSString)
+    deleteDiskFile(fileId: fileId)
+  }
+
+  func clearAll() {
+    memoryCache.removeAllObjects()
+    clearDiskCache()
+  }
+
+  func prefetch(thumbnails: [(fileId: String, url: URL)]) async {
+    await withTaskGroup(of: Void.self) { group in
+      for (fileId, url) in thumbnails {
+        group.addTask {
+          _ = await self.getImage(fileId: fileId, url: url)
+        }
+      }
+    }
+  }
+
+  // MARK: - Disk I/O (Library/Caches/thumbnails/)
+
+  private func cacheDirectory() -> URL? {
+    guard let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+    else { return nil }
+    let dir = cachesDir.appendingPathComponent("thumbnails", isDirectory: true)
+    if !FileManager.default.fileExists(atPath: dir.path) {
+      try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+    return dir
+  }
+
+  private func loadFromDisk(fileId: String) -> UIImage? {
+    guard let dir = cacheDirectory() else { return nil }
+    let path = dir.appendingPathComponent("\(fileId).jpg")
+    guard let data = try? Data(contentsOf: path) else { return nil }
+    return UIImage(data: data)
+  }
+
+  private func saveToDisk(fileId: String, image: UIImage) {
+    guard let dir = cacheDirectory() else { return }
+    let path = dir.appendingPathComponent("\(fileId).jpg")
+    if let jpegData = image.jpegData(compressionQuality: 0.8) {
+      try? jpegData.write(to: path)
+    }
+  }
+
+  private func diskFileExists(fileId: String) -> Bool {
+    guard let dir = cacheDirectory() else { return false }
+    let path = dir.appendingPathComponent("\(fileId).jpg")
+    return FileManager.default.fileExists(atPath: path.path)
+  }
+
+  private func deleteDiskFile(fileId: String) {
+    guard let dir = cacheDirectory() else { return }
+    let path = dir.appendingPathComponent("\(fileId).jpg")
+    try? FileManager.default.removeItem(at: path)
+  }
+
+  private func clearDiskCache() {
+    guard let dir = cacheDirectory() else { return }
+    try? FileManager.default.removeItem(at: dir)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  }
+
+  // MARK: - Old Directory Cleanup (Documents/thumbnails/ -> deleted)
+
+  private static func cleanupOldDirectory() {
+    let fileManager = FileManager.default
+    guard let docsDir = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
+    else { return }
+
+    let oldDir = docsDir.appendingPathComponent("thumbnails", isDirectory: true)
+    guard fileManager.fileExists(atPath: oldDir.path) else { return }
+    try? fileManager.removeItem(at: oldDir)
+  }
 }

--- a/App/Features/FileCellFeature.swift
+++ b/App/Features/FileCellFeature.swift
@@ -13,6 +13,7 @@ struct FileCellFeature {
     var isDownloading: Bool = false
     var downloadProgress: Double = 0
     var isDownloaded: Bool = false // Cached to avoid fileClient.fileExists() in view body
+    var isServerDownloading: Bool = false
     @Presents var alert: AlertState<Action.Alert>?
 
     /// File is pending when metadata is received but no download URL is available yet
@@ -31,6 +32,7 @@ struct FileCellFeature {
     case downloadProgressUpdated(Double)
     case downloadCompleted(URL)
     case downloadFailed(String)
+    case deleteFailed(String)
     case alert(PresentationAction<Alert>)
     case delegate(Delegate)
 
@@ -161,7 +163,11 @@ struct FileCellFeature {
 
       case .deleteButtonTapped:
         let file = state.file
-        return .run { [thumbnailCacheClient] send in
+        let serverClient = serverClient
+        let coreDataClient = coreDataClient
+        let fileClient = fileClient
+        return .run { send in
+          let _ = try await serverClient.deleteFile(file.fileId)
           try await coreDataClient.deleteFile(file)
           if let url = file.url, fileClient.fileExists(url) {
             try await fileClient.deleteFile(url)
@@ -169,7 +175,22 @@ struct FileCellFeature {
           // Also delete cached thumbnail
           await thumbnailCacheClient.deleteThumbnail(file.fileId)
           await send(.delegate(.fileDeleted(file)))
+        } catch: { error, send in
+          await send(.deleteFailed(error.localizedDescription))
         }
+
+      case let .deleteFailed(message):
+        let fileName = state.file.title ?? state.file.key
+        state.alert = AlertState {
+          TextState("Delete Failed")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) {
+            TextState("OK")
+          }
+        } message: {
+          TextState("Could not delete \"\(fileName)\": \(message)")
+        }
+        return .none
 
       case .delegate:
         return .none

--- a/App/Features/FileDetailFeature.swift
+++ b/App/Features/FileDetailFeature.swift
@@ -41,6 +41,7 @@ struct FileDetailFeature {
     }
   }
 
+  @Dependency(\.serverClient) var serverClient
   @Dependency(\.coreDataClient) var coreDataClient
   @Dependency(\.fileClient) var fileClient
   @Dependency(\.downloadClient) var downloadClient
@@ -158,13 +159,19 @@ struct FileDetailFeature {
 
       case .alert(.presented(.confirmDelete)):
         let file = state.file
+        let logger = logger
         return .run { [thumbnailCacheClient] send in
+          let _ = try await serverClient.deleteFile(file.fileId)
           try await coreDataClient.deleteFile(file)
           if let url = file.url, fileClient.fileExists(url) {
             try await fileClient.deleteFile(url)
           }
           // Also delete cached thumbnail
           await thumbnailCacheClient.deleteThumbnail(file.fileId)
+          await send(.delegate(.fileDeleted(file)))
+        } catch: { error, send in
+          logger.error(.network, "Delete failed", metadata: ["fileId": file.fileId, "error": error.localizedDescription])
+          // Still dismiss and report deleted to avoid stuck UI state
           await send(.delegate(.fileDeleted(file)))
         }
 

--- a/App/Features/FileDetailFeature.swift
+++ b/App/Features/FileDetailFeature.swift
@@ -23,6 +23,7 @@ struct FileDetailFeature {
     case downloadProgressUpdated(Double)
     case downloadCompleted(URL)
     case downloadFailed(String)
+    case showDeleteError(fileName: String, message: String)
     case alert(PresentationAction<Alert>)
     case delegate(Delegate)
 
@@ -170,10 +171,23 @@ struct FileDetailFeature {
           await thumbnailCacheClient.deleteThumbnail(file.fileId)
           await send(.delegate(.fileDeleted(file)))
         } catch: { error, send in
-          logger.error(.network, "Delete failed", metadata: ["fileId": file.fileId, "error": error.localizedDescription])
-          // Still dismiss and report deleted to avoid stuck UI state
-          await send(.delegate(.fileDeleted(file)))
+          let message = error.localizedDescription
+          logger.error(.network, "Delete failed", metadata: ["fileId": file.fileId, "error": message])
+          let fileName = file.title ?? file.key
+          await send(.showDeleteError(fileName: fileName, message: message))
         }
+
+      case let .showDeleteError(fileName, message):
+        state.alert = AlertState {
+          TextState("Delete Failed")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) {
+            TextState("OK")
+          }
+        } message: {
+          TextState("Could not delete \"\(fileName)\": \(message)")
+        }
+        return .none
 
       case .alert:
         return .none

--- a/App/Features/FileListFeature.swift
+++ b/App/Features/FileListFeature.swift
@@ -53,7 +53,7 @@ struct FileListFeature {
     // Push notification actions
     case fileAddedFromPush(File)
     case updateFileUrl(fileId: String, url: URL)
-    case fileDownloadStartedOnServer(fileId: String)
+    case fileDownloadStartedOnServer(fileId: String, thumbnailUrl: String?)
     case refreshFileState(String) // fileId
     case fileFailed(fileId: String, error: String)
     case deleteFileFailed(File, String)
@@ -85,6 +85,7 @@ struct FileListFeature {
   @Dependency(\.liveActivityClient) var liveActivityClient
   @Dependency(\.pasteboardClient) var pasteboardClient
   @Dependency(\.fileClient) var fileClient
+  @Dependency(\.thumbnailCacheClient) var thumbnailCacheClient
 
   private enum CancelID {
     case loadFiles
@@ -135,7 +136,11 @@ struct FileListFeature {
           return newState
         })
         state.isLoading = false
-        return .none
+        let thumbnails = thumbnailsToFetch(from: filesToShow)
+        let thumbnailCacheClient = thumbnailCacheClient
+        return thumbnails.isEmpty ? .none : .run { _ in
+          await thumbnailCacheClient.prefetchThumbnails(thumbnails)
+        }
 
       case .clearAllFiles:
         // Clear in-memory state and CoreData/downloaded files
@@ -185,11 +190,16 @@ struct FileListFeature {
         // Share first file with DefaultFilesFeature ONLY for unregistered users
         let firstFile = response.body?.contents.first
         let isRegistered = state.isRegistered
+        let thumbnails = thumbnailsToFetch(from: response.body?.contents ?? [])
+        let thumbnailCacheClient = thumbnailCacheClient
         // Cache files to disk for instant display on next launch
         return .merge(
           isRegistered ? .none : .send(.defaultFiles(.parentProvidedFile(firstFile))),
           .run { [files = response.body?.contents ?? []] _ in
             try await coreDataClient.cacheFiles(files)
+          },
+          thumbnails.isEmpty ? .none : .run { _ in
+            await thumbnailCacheClient.prefetchThumbnails(thumbnails)
           }
         )
 
@@ -426,11 +436,21 @@ struct FileListFeature {
         state.files.sort { ($0.file.publishDate ?? .distantPast) > ($1.file.publishDate ?? .distantPast) }
         // Remove from pending if it was there
         state.pendingFileIds.remove(file.fileId)
-        // For new files, trigger onAppear to check download status
-        if isNewFile {
-          return .send(.files(.element(id: file.fileId, action: .onAppear)))
+
+        let thumbnailCacheClient = thumbnailCacheClient
+        var effects: [Effect<Action>] = []
+
+        if let urlString = file.thumbnailUrl, let url = URL(string: urlString) {
+          effects.append(.run { _ in
+            await thumbnailCacheClient.prefetchThumbnails([(fileId: file.fileId, url: url)])
+          })
         }
-        return .none
+
+        if isNewFile {
+          effects.append(.send(.files(.element(id: file.fileId, action: .onAppear))))
+        }
+
+        return effects.isEmpty ? .none : .merge(effects)
 
       case let .updateFileUrl(fileId, url):
         // Update the file's URL in state (called when download-ready notification arrives)
@@ -441,9 +461,12 @@ struct FileListFeature {
         }
         return .none
 
-      case let .fileDownloadStartedOnServer(fileId):
+      case let .fileDownloadStartedOnServer(fileId, thumbnailUrl):
         if var fileState = state.files[id: fileId] {
           fileState.isServerDownloading = true
+          if let thumbnailUrl {
+            fileState.file.thumbnailUrl = thumbnailUrl
+          }
           state.files[id: fileId] = fileState
         }
         return .run { [liveActivityClient] _ in
@@ -559,5 +582,14 @@ struct FileListFeature {
       FileCellFeature()
     }
     .ifLet(\.$alert, action: \.alert)
+  }
+
+  // MARK: - Helpers
+
+  private func thumbnailsToFetch(from files: [File]) -> [(fileId: String, url: URL)] {
+    files.compactMap { file in
+      guard let urlString = file.thumbnailUrl, let url = URL(string: urlString) else { return nil }
+      return (fileId: file.fileId, url: url)
+    }
   }
 }

--- a/App/Features/FileListFeature.swift
+++ b/App/Features/FileListFeature.swift
@@ -53,8 +53,10 @@ struct FileListFeature {
     // Push notification actions
     case fileAddedFromPush(File)
     case updateFileUrl(fileId: String, url: URL)
+    case fileDownloadStartedOnServer(fileId: String)
     case refreshFileState(String) // fileId
     case fileFailed(fileId: String, error: String)
+    case deleteFileFailed(File, String)
     case clearAllFiles // Clears state and CoreData (used on registration)
     case delegate(Delegate)
 
@@ -82,6 +84,7 @@ struct FileListFeature {
   @Dependency(\.logger) var logger
   @Dependency(\.liveActivityClient) var liveActivityClient
   @Dependency(\.pasteboardClient) var pasteboardClient
+  @Dependency(\.fileClient) var fileClient
 
   private enum CancelID {
     case loadFiles
@@ -127,6 +130,7 @@ struct FileListFeature {
             newState.isDownloaded = existing.isDownloaded
             newState.isDownloading = existing.isDownloading
             newState.downloadProgress = existing.downloadProgress
+            newState.isServerDownloading = existing.isServerDownloading
           }
           return newState
         })
@@ -169,6 +173,7 @@ struct FileListFeature {
               newState.isDownloaded = existing.isDownloaded
               newState.isDownloading = existing.isDownloading
               newState.downloadProgress = existing.downloadProgress
+              newState.isServerDownloading = existing.isServerDownloading
             }
             return newState
           })
@@ -351,10 +356,31 @@ struct FileListFeature {
         return .none
 
       case let .deleteFiles(indexSet):
-        for index in indexSet {
+        let filesToDelete = indexSet.compactMap { index -> File? in
+          guard state.files.indices.contains(index) else { return nil }
+          return state.files[index].file
+        }
+        // Optimistic removal from UI
+        for index in indexSet.sorted().reversed() {
           state.files.remove(at: index)
         }
-        return .none
+        guard !filesToDelete.isEmpty else { return .none }
+        let serverClient = serverClient
+        let coreDataClient = coreDataClient
+        let fileClient = fileClient
+        return .run { send in
+          for file in filesToDelete {
+            do {
+              let _ = try await serverClient.deleteFile(file.fileId)
+              try await coreDataClient.deleteFile(file)
+              if let url = file.url, fileClient.fileExists(url) {
+                try await fileClient.deleteFile(url)
+              }
+            } catch {
+              await send(.deleteFileFailed(file, error.localizedDescription))
+            }
+          }
+        }
 
       case let .files(.element(id: _, action: .delegate(.fileDeleted(file)))):
         state.files.remove(id: file.fileId)
@@ -401,7 +427,6 @@ struct FileListFeature {
         // Remove from pending if it was there
         state.pendingFileIds.remove(file.fileId)
         // For new files, trigger onAppear to check download status
-        // (handles case where metadata notification was missed but file was downloaded)
         if isNewFile {
           return .send(.files(.element(id: file.fileId, action: .onAppear)))
         }
@@ -411,6 +436,14 @@ struct FileListFeature {
         // Update the file's URL in state (called when download-ready notification arrives)
         if var fileState = state.files[id: fileId] {
           fileState.file.url = url
+          fileState.isServerDownloading = false
+          state.files[id: fileId] = fileState
+        }
+        return .none
+
+      case let .fileDownloadStartedOnServer(fileId):
+        if var fileState = state.files[id: fileId] {
+          fileState.isServerDownloading = true
           state.files[id: fileId] = fileState
         }
         return .none
@@ -444,6 +477,22 @@ struct FileListFeature {
           }
         } message: {
           TextState(error)
+        }
+        return .none
+
+      case let .deleteFileFailed(file, errorMessage):
+        // Re-insert the file and show an error
+        state.files.append(FileCellFeature.State(file: file))
+        state.files.sort { ($0.file.publishDate ?? .distantPast) > ($1.file.publishDate ?? .distantPast) }
+        let fileName = file.title ?? file.key
+        state.alert = AlertState {
+          TextState("Delete Failed")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) {
+            TextState("OK")
+          }
+        } message: {
+          TextState("Failed to delete \"\(fileName)\": \(errorMessage)")
         }
         return .none
 

--- a/App/Features/FileListFeature.swift
+++ b/App/Features/FileListFeature.swift
@@ -446,7 +446,9 @@ struct FileListFeature {
           fileState.isServerDownloading = true
           state.files[id: fileId] = fileState
         }
-        return .none
+        return .run { [liveActivityClient] _ in
+          await liveActivityClient.updateProgress(fileId, 0, .serverDownloading)
+        }
 
       case let .refreshFileState(fileId):
         // If file exists in state, trigger onAppear to re-check download status

--- a/App/Features/FileListFeature.swift
+++ b/App/Features/FileListFeature.swift
@@ -509,8 +509,7 @@ struct FileListFeature {
       // Handle delegate actions from FileDetailFeature
       case let .detail(.presented(.delegate(.fileDeleted(file)))):
         state.files.remove(id: file.fileId)
-        state.selectedFile = nil
-        return .none
+        return .send(.detail(.dismiss))
 
       case let .detail(.presented(.delegate(.playFile(file)))):
         state.isPreparingToPlay = true

--- a/App/Features/RootFeature.swift
+++ b/App/Features/RootFeature.swift
@@ -285,6 +285,9 @@ struct RootFeature {
             await send(.downloadReadyProcessed(fileId: fileId, key: key, url: url, size: size))
           }
 
+        case let .downloadStarted(fileId):
+          return .send(.main(.fileList(.fileDownloadStartedOnServer(fileId: fileId))))
+
         case let .failure(fileId, _, _, errorMessage):
           // Update file status to failed in CoreData and UI, end Live Activity
           return .run { [coreDataClient, liveActivityClient] send in

--- a/App/Features/RootFeature.swift
+++ b/App/Features/RootFeature.swift
@@ -91,6 +91,7 @@ struct RootFeature {
   @Dependency(\.logger) var logger
   @Dependency(\.notificationRegistrationClient) var notificationRegistrationClient
   @Dependency(\.liveActivityClient) var liveActivityClient
+  @Dependency(\.thumbnailCacheClient) var thumbnailCacheClient
 
   var body: some ReducerOf<Self> {
     Scope(state: \.login, action: \.login) {
@@ -285,8 +286,15 @@ struct RootFeature {
             await send(.downloadReadyProcessed(fileId: fileId, key: key, url: url, size: size))
           }
 
-        case let .downloadStarted(fileId):
-          return .send(.main(.fileList(.fileDownloadStartedOnServer(fileId: fileId))))
+        case let .downloadStarted(fileId, thumbnailUrl, _):
+          let thumbnailCacheClient = thumbnailCacheClient
+          return .merge(
+            .send(.main(.fileList(.fileDownloadStartedOnServer(fileId: fileId, thumbnailUrl: thumbnailUrl)))),
+            .run { _ in
+              guard let urlString = thumbnailUrl, let url = URL(string: urlString) else { return }
+              await thumbnailCacheClient.prefetchThumbnails([(fileId: fileId, url: url)])
+            }
+          )
 
         case let .failure(fileId, _, _, errorMessage):
           // Update file status to failed in CoreData and UI, end Live Activity
@@ -303,10 +311,15 @@ struct RootFeature {
 
       case let .fileMetadataSaved(file):
         // Forward to MainFeature to update FileList and start Live Activity
+        let thumbnailCacheClient = thumbnailCacheClient
         return .merge(
           .send(.main(.fileList(.fileAddedFromPush(file)))),
           .run { [liveActivityClient] _ in
             await liveActivityClient.startActivity(file)
+          },
+          .run { _ in
+            guard let urlString = file.thumbnailUrl, let url = URL(string: urlString) else { return }
+            await thumbnailCacheClient.prefetchThumbnails([(fileId: file.fileId, url: url)])
           }
         )
 

--- a/App/LiveActivity/DownloadActivityAttributes.swift
+++ b/App/LiveActivity/DownloadActivityAttributes.swift
@@ -17,6 +17,7 @@ struct DownloadActivityAttributes: ActivityAttributes {
 
 enum DownloadActivityStatus: String, Codable {
   case queued = "Queued"
+  case serverDownloading = "Server downloading..."
   case downloading = "Downloading"
   case downloaded = "Downloaded"
   case failed = "Failed"

--- a/App/LiveActivity/LiveActivityManager.swift
+++ b/App/LiveActivity/LiveActivityManager.swift
@@ -115,13 +115,17 @@ actor LiveActivityManager {
       return
     }
 
+    let previousStatus = state.status
     state.status = status
     state.progressPercent = percent
     currentStates[fileId] = state
 
     nonisolated(unsafe) let unsafeActivity = activity
     await unsafeActivity.update(ActivityContent(state: state, staleDate: nil))
-    logger.debug("Live Activity updated for fileId: \(fileId), progress: \(percent)%, status: \(status.rawValue)")
+    // Only log status transitions and milestones (25% intervals) to reduce noise
+    if status != previousStatus || percent % 25 == 0 {
+      logger.debug("Live Activity: \(fileId) \(status.rawValue) \(percent)%")
+    }
   }
 
   func endActivity(fileId: String, status: DownloadActivityStatus, errorMessage: String? = nil) async {

--- a/App/Models/DeleteFileResponse.swift
+++ b/App/Models/DeleteFileResponse.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-struct DeleteFileResponseDetail: Codable {
+struct DeleteFileResponseDetail: Codable, Sendable {
     var deleted: Bool
     var fileRemoved: Bool
 }
 
-struct DeleteFileResponse: Codable {
+struct DeleteFileResponse: Codable, Sendable {
     var body: DeleteFileResponseDetail?
     var error: ErrorDetail?
     var requestId: String

--- a/App/Models/DeleteFileResponse.swift
+++ b/App/Models/DeleteFileResponse.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct DeleteFileResponseDetail: Codable {
+    var deleted: Bool
+    var fileRemoved: Bool
+}
+
+struct DeleteFileResponse: Codable {
+    var body: DeleteFileResponseDetail?
+    var error: ErrorDetail?
+    var requestId: String
+}

--- a/App/Models/DeleteFileResponse.swift
+++ b/App/Models/DeleteFileResponse.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-struct DeleteFileResponseDetail: Codable, Sendable {
-    var deleted: Bool
-    var fileRemoved: Bool
+struct DeleteFileResponseDetail: Codable {
+  var deleted: Bool
+  var fileRemoved: Bool
 }
 
-struct DeleteFileResponse: Codable, Sendable {
-    var body: DeleteFileResponseDetail?
-    var error: ErrorDetail?
-    var requestId: String
+struct DeleteFileResponse: Codable {
+  var body: DeleteFileResponseDetail?
+  var error: ErrorDetail?
+  var requestId: String
 }

--- a/App/Models/PushNotification.swift
+++ b/App/Models/PushNotification.swift
@@ -7,6 +7,8 @@ enum PushNotificationType: Equatable {
   case metadata(File)
   /// Download URL is ready - can start downloading
   case downloadReady(fileId: String, key: String, url: URL, size: Int64)
+  /// Server has started downloading the file to S3
+  case downloadStarted(fileId: String)
   /// File processing failed
   case failure(fileId: String, title: String?, errorCategory: String, errorMessage: String)
   /// Unknown or malformed notification
@@ -45,6 +47,13 @@ enum PushNotificationType: Equatable {
         return .unknown
       }
       return .downloadReady(fileId: fileId, key: key, url: url, size: Int64(size))
+
+    case "DownloadStartedNotification":
+      guard let fileId = fileData["fileId"] as? String else {
+        logger.warning(.push, "Missing fileId in DownloadStartedNotification")
+        return .unknown
+      }
+      return .downloadStarted(fileId: fileId)
 
     case "FailureNotification":
       guard let fileId = fileData["fileId"] as? String,

--- a/App/Models/PushNotification.swift
+++ b/App/Models/PushNotification.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import Foundation
 
 /// Represents the type of push notification received for file operations
-enum PushNotificationType: Equatable, Sendable {
+enum PushNotificationType: Equatable {
   /// Full file metadata received (no url, no size) - file is being processed on server
   case metadata(File)
   /// Download URL is ready - can start downloading

--- a/App/Models/PushNotification.swift
+++ b/App/Models/PushNotification.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import Foundation
 
 /// Represents the type of push notification received for file operations
-enum PushNotificationType: Equatable {
+enum PushNotificationType: Equatable, Sendable {
   /// Full file metadata received (no url, no size) - file is being processed on server
   case metadata(File)
   /// Download URL is ready - can start downloading

--- a/App/Models/PushNotification.swift
+++ b/App/Models/PushNotification.swift
@@ -8,7 +8,7 @@ enum PushNotificationType: Equatable {
   /// Download URL is ready - can start downloading
   case downloadReady(fileId: String, key: String, url: URL, size: Int64)
   /// Server has started downloading the file to S3
-  case downloadStarted(fileId: String)
+  case downloadStarted(fileId: String, thumbnailUrl: String?, title: String?)
   /// File processing failed
   case failure(fileId: String, title: String?, errorCategory: String, errorMessage: String)
   /// Unknown or malformed notification
@@ -53,7 +53,9 @@ enum PushNotificationType: Equatable {
         logger.warning(.push, "Missing fileId in DownloadStartedNotification")
         return .unknown
       }
-      return .downloadStarted(fileId: fileId)
+      let thumbnailUrl = fileData["thumbnailUrl"] as? String
+      let title = fileData["title"] as? String
+      return .downloadStarted(fileId: fileId, thumbnailUrl: thumbnailUrl, title: title)
 
     case "FailureNotification":
       guard let fileId = fileData["fileId"] as? String,

--- a/App/Views/FileListView.swift
+++ b/App/Views/FileListView.swift
@@ -136,6 +136,14 @@ struct FileCellView: View {
       Text("Processing...")
         .font(.caption2)
         .foregroundStyle(theme.warningColor)
+    } else if store.isServerDownloading, !store.isDownloading, !store.isDownloaded {
+      HStack(spacing: 4) {
+        Image(systemName: "icloud.and.arrow.down")
+          .font(.caption2)
+        Text("Server downloading...")
+      }
+      .font(.caption2)
+      .foregroundStyle(Color.cyan)
     } else if store.isDownloading {
       Text("Downloading \(Int(store.downloadProgress * 100))%")
         .font(.caption2)

--- a/App/Views/FileListView.swift
+++ b/App/Views/FileListView.swift
@@ -352,27 +352,27 @@ struct FileListView: View {
   }
 
   private var fileList: some View {
-    ScrollView {
-      LazyVStack(spacing: 0) {
-        ForEach(store.scope(state: \.files, action: \.files)) { cellStore in
-          FileCellView(store: cellStore)
-            .contentShape(Rectangle())
-            .onTapGesture {
-              store.send(.fileTapped(cellStore.state))
-            }
-            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-              Button(role: .destructive) {
-                if let index = store.files.firstIndex(where: { $0.id == cellStore.state.id }) {
-                  store.send(.deleteFiles(IndexSet(integer: index)))
-                }
-              } label: {
-                Label("Delete", systemImage: "trash")
+    List {
+      ForEach(store.scope(state: \.files, action: \.files)) { cellStore in
+        FileCellView(store: cellStore)
+          .contentShape(Rectangle())
+          .onTapGesture {
+            store.send(.fileTapped(cellStore.state))
+          }
+          .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+              if let index = store.files.firstIndex(where: { $0.id == cellStore.state.id }) {
+                store.send(.deleteFiles(IndexSet(integer: index)))
               }
+            } label: {
+              Label("Delete", systemImage: "trash")
             }
-        }
+          }
+          .listRowInsets(EdgeInsets())
+          .listRowSeparator(.hidden)
       }
-      .padding(.vertical, 12)
     }
+    .listStyle(.plain)
     .refreshable {
       store.send(.refreshButtonTapped)
     }

--- a/DownloadActivityWidget/DownloadActivityWidget.swift
+++ b/DownloadActivityWidget/DownloadActivityWidget.swift
@@ -24,6 +24,7 @@ struct DownloadActivityAttributes: ActivityAttributes {
 
 enum DownloadActivityStatus: String, Codable {
   case queued = "Queued"
+  case serverDownloading = "Server downloading..."
   case downloading = "Downloading"
   case downloaded = "Downloaded"
   case failed = "Failed"
@@ -98,6 +99,9 @@ struct DownloadActivityWidget: Widget {
     case .queued:
       Image(systemName: "clock.fill")
         .foregroundStyle(.orange)
+    case .serverDownloading:
+      Image(systemName: "icloud.and.arrow.down.fill")
+        .foregroundStyle(.cyan)
     case .downloading:
       Image(systemName: "arrow.down.circle.fill")
         .foregroundStyle(.blue)
@@ -113,6 +117,7 @@ struct DownloadActivityWidget: Widget {
   private func progressColor(for status: DownloadActivityStatus) -> Color {
     switch status {
     case .queued: .orange
+    case .serverDownloading: .cyan
     case .downloading: .blue
     case .downloaded: .green
     case .failed: .red
@@ -151,7 +156,7 @@ struct LockScreenView: View {
 
       Spacer()
 
-      if context.state.status == .downloading {
+      if context.state.status == .downloading || context.state.status == .serverDownloading {
         VStack {
           Text("\(context.state.progressPercent)%")
             .font(.headline)
@@ -175,6 +180,9 @@ struct LockScreenView: View {
     case .queued:
       Image(systemName: "clock.fill")
         .foregroundStyle(.orange)
+    case .serverDownloading:
+      Image(systemName: "icloud.and.arrow.down.fill")
+        .foregroundStyle(.cyan)
     case .downloading:
       Image(systemName: "arrow.down.circle.fill")
         .foregroundStyle(.blue)
@@ -201,6 +209,7 @@ struct LockScreenView: View {
   private var badgeColor: Color {
     switch context.state.status {
     case .queued: .orange
+    case .serverDownloading: .cyan
     case .downloading: .blue
     case .downloaded: .green
     case .failed: .red

--- a/OfflineMediaDownloaderTests/FileCellFeatureTests.swift
+++ b/OfflineMediaDownloaderTests/FileCellFeatureTests.swift
@@ -240,8 +240,9 @@ struct FileCellFeatureTests {
   // MARK: - Delete Tests
 
   @MainActor
-  @Test("Delete button triggers file deletion from CoreData, filesystem, and thumbnail cache")
+  @Test("Delete button triggers server delete, CoreData, filesystem, and thumbnail cache removal")
   func deleteRemovesFiles() async {
+    let serverDeleteCalled = LockIsolated(false)
     let coreDataDeleteCalled = LockIsolated(false)
     let fileDeleteCalled = LockIsolated(false)
     let thumbnailDeleteCalled = LockIsolated(false)
@@ -250,6 +251,14 @@ struct FileCellFeatureTests {
       FileCellFeature()
     } withDependencies: {
       $0.logger = TestData.noopLogger
+      $0.serverClient.deleteFile = { _ in
+        serverDeleteCalled.setValue(true)
+        return DeleteFileResponse(
+          body: DeleteFileResponseDetail(deleted: true, fileRemoved: true),
+          error: nil,
+          requestId: "test"
+        )
+      }
       $0.coreDataClient.deleteFile = { _ in coreDataDeleteCalled.setValue(true) }
       $0.fileClient.fileExists = { _ in true }
       $0.fileClient.deleteFile = { _ in fileDeleteCalled.setValue(true) }
@@ -259,14 +268,16 @@ struct FileCellFeatureTests {
     await store.send(.deleteButtonTapped)
     await store.receive(\.delegate.fileDeleted)
 
+    #expect(serverDeleteCalled.value == true)
     #expect(coreDataDeleteCalled.value == true)
     #expect(fileDeleteCalled.value == true)
     #expect(thumbnailDeleteCalled.value == true)
   }
 
   @MainActor
-  @Test("Delete skips local file removal if not exists but still deletes thumbnail")
+  @Test("Delete skips local file removal if not exists but still calls server and deletes thumbnail")
   func deleteSkipsIfNotExists() async {
+    let serverDeleteCalled = LockIsolated(false)
     let fileDeleteCalled = LockIsolated(false)
     let thumbnailDeleteCalled = LockIsolated(false)
 
@@ -274,6 +285,14 @@ struct FileCellFeatureTests {
       FileCellFeature()
     } withDependencies: {
       $0.logger = TestData.noopLogger
+      $0.serverClient.deleteFile = { _ in
+        serverDeleteCalled.setValue(true)
+        return DeleteFileResponse(
+          body: DeleteFileResponseDetail(deleted: true, fileRemoved: true),
+          error: nil,
+          requestId: "test"
+        )
+      }
       $0.coreDataClient.deleteFile = { _ in }
       $0.fileClient.fileExists = { _ in false }
       $0.fileClient.deleteFile = { _ in fileDeleteCalled.setValue(true) }
@@ -283,13 +302,15 @@ struct FileCellFeatureTests {
     await store.send(.deleteButtonTapped)
     await store.receive(\.delegate.fileDeleted)
 
+    #expect(serverDeleteCalled.value == true)
     #expect(fileDeleteCalled.value == false)
     #expect(thumbnailDeleteCalled.value == true)
   }
 
   @MainActor
-  @Test("Delete with nil URL still removes from CoreData and thumbnail cache")
+  @Test("Delete with nil URL still calls server, removes from CoreData and thumbnail cache")
   func deleteWithNilUrl() async {
+    let serverDeleteCalled = LockIsolated(false)
     let coreDataDeleteCalled = LockIsolated(false)
     let thumbnailDeleteCalled = LockIsolated(false)
 
@@ -297,6 +318,14 @@ struct FileCellFeatureTests {
       FileCellFeature()
     } withDependencies: {
       $0.logger = TestData.noopLogger
+      $0.serverClient.deleteFile = { _ in
+        serverDeleteCalled.setValue(true)
+        return DeleteFileResponse(
+          body: DeleteFileResponseDetail(deleted: true, fileRemoved: true),
+          error: nil,
+          requestId: "test"
+        )
+      }
       $0.coreDataClient.deleteFile = { _ in coreDataDeleteCalled.setValue(true) }
       $0.fileClient.fileExists = { _ in false }
       $0.thumbnailCacheClient.deleteThumbnail = { _ in thumbnailDeleteCalled.setValue(true) }
@@ -305,6 +334,7 @@ struct FileCellFeatureTests {
     await store.send(.deleteButtonTapped)
     await store.receive(\.delegate.fileDeleted)
 
+    #expect(serverDeleteCalled.value == true)
     #expect(coreDataDeleteCalled.value == true)
     #expect(thumbnailDeleteCalled.value == true)
   }

--- a/OfflineMediaDownloaderTests/FileListFeatureTests.swift
+++ b/OfflineMediaDownloaderTests/FileListFeatureTests.swift
@@ -668,6 +668,7 @@ struct FileListFeatureTests {
 
     await store.send(.updateFileUrl(fileId: pendingFile.fileId, url: newUrl)) {
       $0.files[id: pendingFile.fileId]?.file.url = newUrl
+      $0.files[id: pendingFile.fileId]?.isServerDownloading = false
     }
   }
 
@@ -699,7 +700,7 @@ struct FileListFeatureTests {
   // MARK: - Delete Tests
 
   @MainActor
-  @Test("Delete files removes from state")
+  @Test("Delete files removes from state and calls server")
   func deleteFilesRemoves() async {
     var state = FileListFeature.State()
     state.files = IdentifiedArray(uniqueElements: TestData.multipleFiles.map {
@@ -711,6 +712,15 @@ struct FileListFeatureTests {
     } withDependencies: {
       $0.logger = TestData.noopLogger
       $0.pasteboardClient = TestData.noopPasteboardClient
+      $0.serverClient.deleteFile = { _ in
+        DeleteFileResponse(
+          body: DeleteFileResponseDetail(deleted: true, fileRemoved: true),
+          error: nil,
+          requestId: "test"
+        )
+      }
+      $0.coreDataClient.deleteFile = { _ in }
+      $0.fileClient.fileExists = { _ in false }
     }
 
     await store.send(.deleteFiles(IndexSet(integer: 0))) {

--- a/OfflineMediaDownloaderTests/ThumbnailCacheClientTests.swift
+++ b/OfflineMediaDownloaderTests/ThumbnailCacheClientTests.swift
@@ -14,9 +14,9 @@ struct ThumbnailCacheClientTests {
   }
 
   @Test("testValue returns false for hasCachedThumbnail")
-  func valueHasCached() {
+  func valueHasCached() async {
     let client = ThumbnailCacheClient.testValue
-    let result = client.hasCachedThumbnail("test-id")
+    let result = await client.hasCachedThumbnail("test-id")
     #expect(result == false)
   }
 

--- a/Packages/OMDFeatures/Package.swift
+++ b/Packages/OMDFeatures/Package.swift
@@ -186,7 +186,7 @@ let package = Package(
       "SharedModels", "DesignSystem",
       "FileCellFeature", "FileDetailFeature", "DefaultFilesFeature",
       "ServerClient", "PersistenceClient", "LoggerClient",
-      "LiveActivityClient", "PasteboardClient",
+      "LiveActivityClient", "PasteboardClient", "ThumbnailCacheClient",
       .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
     ]),
 
@@ -202,6 +202,7 @@ let package = Package(
       "AuthenticationClient", "ServerClient", "KeychainClient",
       "PersistenceClient", "DownloadClient", "FileClient",
       "LoggerClient", "NotificationRegistrationClient", "LiveActivityClient",
+      "ThumbnailCacheClient",
       .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
     ]),
 

--- a/Packages/OMDFeatures/Sources/FileCellFeature/FileCellFeature.swift
+++ b/Packages/OMDFeatures/Sources/FileCellFeature/FileCellFeature.swift
@@ -20,6 +20,7 @@ public struct FileCellFeature: Sendable {
     }
 
     public var isDownloading: Bool = false
+    public var isServerDownloading: Bool = false
     public var downloadProgress: Double = 0
     public var isDownloaded: Bool = false
     @Presents public var alert: AlertState<Action.Alert>?

--- a/Packages/OMDFeatures/Sources/FileCellFeature/FileCellView.swift
+++ b/Packages/OMDFeatures/Sources/FileCellFeature/FileCellView.swift
@@ -110,6 +110,11 @@ public struct FileCellView: View {
         .font(.system(size: 22))
         .foregroundStyle(theme.warningColor)
         .shadow(color: .black.opacity(0.5), radius: 2)
+    } else if store.isServerDownloading {
+      Image(systemName: "icloud.and.arrow.down")
+        .font(.system(size: 22))
+        .foregroundStyle(.cyan)
+        .shadow(color: .black.opacity(0.5), radius: 2)
     } else if store.isDownloading {
       // Show mini progress in thumbnail during download
       ZStack {
@@ -139,6 +144,10 @@ public struct FileCellView: View {
       Text("Processing...")
         .font(.caption2)
         .foregroundStyle(theme.warningColor)
+    } else if store.isServerDownloading {
+      Text("Server downloading...")
+        .font(.caption2)
+        .foregroundStyle(.cyan)
     } else if store.isDownloading {
       Text("Downloading \(Int(store.downloadProgress * 100))%")
         .font(.caption2)

--- a/Packages/OMDFeatures/Sources/FileListFeature/FileListFeature.swift
+++ b/Packages/OMDFeatures/Sources/FileListFeature/FileListFeature.swift
@@ -60,6 +60,7 @@ public struct FileListFeature: Sendable {
     case defaultFiles(DefaultFilesFeature.Action)
     case fileAddedFromPush(File)
     case updateFileUrl(fileId: String, url: URL)
+    case fileDownloadStartedOnServer(fileId: String)
     case refreshFileState(String)
     case fileFailed(fileId: String, error: String)
     case clearAllFiles
@@ -126,6 +127,7 @@ public struct FileListFeature: Sendable {
           if let existing = existingStates[file.fileId] {
             newState.isDownloaded = existing.isDownloaded
             newState.isDownloading = existing.isDownloading
+            newState.isServerDownloading = existing.isServerDownloading
             newState.downloadProgress = existing.downloadProgress
           }
           return newState
@@ -163,6 +165,7 @@ public struct FileListFeature: Sendable {
             if let existing = existingStates[file.fileId] {
               newState.isDownloaded = existing.isDownloaded
               newState.isDownloading = existing.isDownloading
+              newState.isServerDownloading = existing.isServerDownloading
               newState.downloadProgress = existing.downloadProgress
             }
             return newState
@@ -385,6 +388,14 @@ public struct FileListFeature: Sendable {
       case let .updateFileUrl(fileId, url):
         if var fileState = state.files[id: fileId] {
           fileState.file.url = url
+          fileState.isServerDownloading = false
+          state.files[id: fileId] = fileState
+        }
+        return .none
+
+      case let .fileDownloadStartedOnServer(fileId):
+        if var fileState = state.files[id: fileId] {
+          fileState.isServerDownloading = true
           state.files[id: fileId] = fileState
         }
         return .none

--- a/Packages/OMDFeatures/Sources/FileListFeature/FileListFeature.swift
+++ b/Packages/OMDFeatures/Sources/FileListFeature/FileListFeature.swift
@@ -11,6 +11,7 @@ import PasteboardClient
 import PersistenceClient
 import ServerClient
 import SharedModels
+import ThumbnailCacheClient
 import UIKit
 
 @Reducer
@@ -60,7 +61,7 @@ public struct FileListFeature: Sendable {
     case defaultFiles(DefaultFilesFeature.Action)
     case fileAddedFromPush(File)
     case updateFileUrl(fileId: String, url: URL)
-    case fileDownloadStartedOnServer(fileId: String)
+    case fileDownloadStartedOnServer(fileId: String, thumbnailUrl: String?)
     case refreshFileState(String)
     case fileFailed(fileId: String, error: String)
     case clearAllFiles
@@ -89,6 +90,7 @@ public struct FileListFeature: Sendable {
   @Dependency(\.logger) var logger
   @Dependency(\.liveActivityClient) var liveActivityClient
   @Dependency(\.pasteboardClient) var pasteboardClient
+  @Dependency(\.thumbnailCacheClient) var thumbnailCacheClient
 
   private enum CancelID {
     case loadFiles
@@ -133,7 +135,11 @@ public struct FileListFeature: Sendable {
           return newState
         })
         state.isLoading = false
-        return .none
+        let thumbnails = thumbnailsToFetch(from: filesToShow)
+        let thumbnailCacheClient = thumbnailCacheClient
+        return thumbnails.isEmpty ? .none : .run { _ in
+          await thumbnailCacheClient.prefetchThumbnails(thumbnails)
+        }
 
       case .clearAllFiles:
         state.files = []
@@ -176,10 +182,15 @@ public struct FileListFeature: Sendable {
         state.isLoading = false
         let firstFile = response.body?.contents.first
         let isRegistered = state.isRegistered
+        let thumbnails = thumbnailsToFetch(from: response.body?.contents ?? [])
+        let thumbnailCacheClient = thumbnailCacheClient
         return .merge(
           isRegistered ? .none : .send(.defaultFiles(.parentProvidedFile(firstFile))),
           .run { [files = response.body?.contents ?? []] _ in
             try await coreDataClient.cacheFiles(files)
+          },
+          thumbnails.isEmpty ? .none : .run { _ in
+            await thumbnailCacheClient.prefetchThumbnails(thumbnails)
           }
         )
 
@@ -380,10 +391,21 @@ public struct FileListFeature: Sendable {
         }
         state.files.sort { ($0.file.publishDate ?? .distantPast) > ($1.file.publishDate ?? .distantPast) }
         state.pendingFileIds.remove(file.fileId)
-        if isNewFile {
-          return .send(.files(.element(id: file.fileId, action: .onAppear)))
+
+        let thumbnailCacheClient = thumbnailCacheClient
+        var effects: [Effect<Action>] = []
+
+        if let urlString = file.thumbnailUrl, let url = URL(string: urlString) {
+          effects.append(.run { _ in
+            await thumbnailCacheClient.prefetchThumbnails([(fileId: file.fileId, url: url)])
+          })
         }
-        return .none
+
+        if isNewFile {
+          effects.append(.send(.files(.element(id: file.fileId, action: .onAppear))))
+        }
+
+        return effects.isEmpty ? .none : .merge(effects)
 
       case let .updateFileUrl(fileId, url):
         if var fileState = state.files[id: fileId] {
@@ -393,9 +415,12 @@ public struct FileListFeature: Sendable {
         }
         return .none
 
-      case let .fileDownloadStartedOnServer(fileId):
+      case let .fileDownloadStartedOnServer(fileId, thumbnailUrl):
         if var fileState = state.files[id: fileId] {
           fileState.isServerDownloading = true
+          if let thumbnailUrl {
+            fileState.file.thumbnailUrl = thumbnailUrl
+          }
           state.files[id: fileId] = fileState
         }
         return .none
@@ -484,5 +509,14 @@ public struct FileListFeature: Sendable {
       FileCellFeature()
     }
     .ifLet(\.$alert, action: \.alert)
+  }
+
+  // MARK: - Helpers
+
+  private func thumbnailsToFetch(from files: [File]) -> [(fileId: String, url: URL)] {
+    files.compactMap { file in
+      guard let urlString = file.thumbnailUrl, let url = URL(string: urlString) else { return nil }
+      return (fileId: file.fileId, url: url)
+    }
   }
 }

--- a/Packages/OMDFeatures/Sources/LiveActivityClient/DownloadActivityAttributes.swift
+++ b/Packages/OMDFeatures/Sources/LiveActivityClient/DownloadActivityAttributes.swift
@@ -27,6 +27,7 @@ public struct DownloadActivityAttributes: ActivityAttributes {
 
 public enum DownloadActivityStatus: String, Codable, Sendable {
   case queued = "Queued"
+  case serverDownloading = "Server downloading..."
   case downloading = "Downloading"
   case downloaded = "Downloaded"
   case failed = "Failed"

--- a/Packages/OMDFeatures/Sources/RootFeature/PushNotification.swift
+++ b/Packages/OMDFeatures/Sources/RootFeature/PushNotification.swift
@@ -7,6 +7,7 @@ import SharedModels
 public enum PushNotificationType: Equatable, Sendable {
   case metadata(File)
   case downloadReady(fileId: String, key: String, url: URL, size: Int64)
+  case downloadStarted(fileId: String)
   case failure(fileId: String, title: String?, errorCategory: String, errorMessage: String)
   case unknown
 
@@ -41,6 +42,13 @@ public enum PushNotificationType: Equatable, Sendable {
         return .unknown
       }
       return .downloadReady(fileId: fileId, key: key, url: url, size: Int64(size))
+
+    case "DownloadStartedNotification":
+      guard let fileId = fileData["fileId"] as? String else {
+        logger.warning(.push, "Missing fileId in DownloadStartedNotification")
+        return .unknown
+      }
+      return .downloadStarted(fileId: fileId)
 
     case "FailureNotification":
       guard let fileId = fileData["fileId"] as? String,

--- a/Packages/OMDFeatures/Sources/RootFeature/PushNotification.swift
+++ b/Packages/OMDFeatures/Sources/RootFeature/PushNotification.swift
@@ -7,7 +7,7 @@ import SharedModels
 public enum PushNotificationType: Equatable, Sendable {
   case metadata(File)
   case downloadReady(fileId: String, key: String, url: URL, size: Int64)
-  case downloadStarted(fileId: String)
+  case downloadStarted(fileId: String, thumbnailUrl: String?, title: String?)
   case failure(fileId: String, title: String?, errorCategory: String, errorMessage: String)
   case unknown
 
@@ -48,7 +48,9 @@ public enum PushNotificationType: Equatable, Sendable {
         logger.warning(.push, "Missing fileId in DownloadStartedNotification")
         return .unknown
       }
-      return .downloadStarted(fileId: fileId)
+      let thumbnailUrl = fileData["thumbnailUrl"] as? String
+      let title = fileData["title"] as? String
+      return .downloadStarted(fileId: fileId, thumbnailUrl: thumbnailUrl, title: title)
 
     case "FailureNotification":
       guard let fileId = fileData["fileId"] as? String,

--- a/Packages/OMDFeatures/Sources/RootFeature/RootFeature.swift
+++ b/Packages/OMDFeatures/Sources/RootFeature/RootFeature.swift
@@ -16,6 +16,7 @@ import PersistenceClient
 import ServerClient
 import SharedModels
 import SwiftUI
+import ThumbnailCacheClient
 import UserNotifications
 
 // MARK: - Notification Setup Helper
@@ -105,6 +106,7 @@ public struct RootFeature: Sendable {
   @Dependency(\.logger) var logger
   @Dependency(\.notificationRegistrationClient) var notificationRegistrationClient
   @Dependency(\.liveActivityClient) var liveActivityClient
+  @Dependency(\.thumbnailCacheClient) var thumbnailCacheClient
 
   public var body: some ReducerOf<Self> {
     Scope(state: \.login, action: \.login) {
@@ -279,8 +281,15 @@ public struct RootFeature: Sendable {
             await send(.downloadReadyProcessed(fileId: fileId, key: key, url: url, size: size))
           }
 
-        case let .downloadStarted(fileId):
-          return .send(.main(.fileList(.fileDownloadStartedOnServer(fileId: fileId))))
+        case let .downloadStarted(fileId, thumbnailUrl, _):
+          let thumbnailCacheClient = thumbnailCacheClient
+          return .merge(
+            .send(.main(.fileList(.fileDownloadStartedOnServer(fileId: fileId, thumbnailUrl: thumbnailUrl)))),
+            .run { _ in
+              guard let urlString = thumbnailUrl, let url = URL(string: urlString) else { return }
+              await thumbnailCacheClient.prefetchThumbnails([(fileId: fileId, url: url)])
+            }
+          )
 
         case let .failure(fileId, _, _, errorMessage):
           return .run { [coreDataClient, liveActivityClient] send in
@@ -295,10 +304,15 @@ public struct RootFeature: Sendable {
         }
 
       case let .fileMetadataSaved(file):
+        let thumbnailCacheClient = thumbnailCacheClient
         return .merge(
           .send(.main(.fileList(.fileAddedFromPush(file)))),
           .run { [liveActivityClient] _ in
             await liveActivityClient.startActivity(file)
+          },
+          .run { _ in
+            guard let urlString = file.thumbnailUrl, let url = URL(string: urlString) else { return }
+            await thumbnailCacheClient.prefetchThumbnails([(fileId: file.fileId, url: url)])
           }
         )
 

--- a/Packages/OMDFeatures/Sources/RootFeature/RootFeature.swift
+++ b/Packages/OMDFeatures/Sources/RootFeature/RootFeature.swift
@@ -279,6 +279,9 @@ public struct RootFeature: Sendable {
             await send(.downloadReadyProcessed(fileId: fileId, key: key, url: url, size: size))
           }
 
+        case let .downloadStarted(fileId):
+          return .send(.main(.fileList(.fileDownloadStartedOnServer(fileId: fileId))))
+
         case let .failure(fileId, _, _, errorMessage):
           return .run { [coreDataClient, liveActivityClient] send in
             await liveActivityClient.endActivity(fileId: fileId, status: .failed, errorMessage: errorMessage)

--- a/Packages/OMDFeatures/Sources/ServerClient/ServerClient.swift
+++ b/Packages/OMDFeatures/Sources/ServerClient/ServerClient.swift
@@ -364,7 +364,7 @@ extension ServerClient: DependencyKey {
       let client = makeAuthenticatedAPIClient()
 
       let response = try await client.getFiles(
-        body: .json(Components.Schemas.Models_period_ListFilesQuery(status: statusFilter.rawValue))
+        query: .init(status: statusFilter.rawValue)
       )
 
       return try handleAPIResponse(

--- a/Packages/OMDFeatures/Sources/ThumbnailCacheClient/ThumbnailCacheClient.swift
+++ b/Packages/OMDFeatures/Sources/ThumbnailCacheClient/ThumbnailCacheClient.swift
@@ -1,17 +1,19 @@
 import ComposableArchitecture
 import UIKit
 
-/// Client for caching thumbnail images to disk
+/// Client for caching thumbnail images with two-tier cache (memory + disk)
 @DependencyClient
 public struct ThumbnailCacheClient: Sendable {
   /// Get thumbnail for a file, fetching from network if not cached
   public var getThumbnail: @Sendable (_ fileId: String, _ url: URL) async -> UIImage?
-  /// Check if thumbnail exists in cache
-  public var hasCachedThumbnail: @Sendable (_ fileId: String) -> Bool = { _ in false }
+  /// Check if thumbnail exists in cache (memory or disk)
+  public var hasCachedThumbnail: @Sendable (_ fileId: String) async -> Bool = { _ in false }
   /// Delete cached thumbnail for a file
   public var deleteThumbnail: @Sendable (_ fileId: String) async -> Void
   /// Clear all cached thumbnails
   public var clearCache: @Sendable () async -> Void
+  /// Pre-fetch and cache thumbnails in background (fire-and-forget from reducers)
+  public var prefetchThumbnails: @Sendable (_ thumbnails: [(fileId: String, url: URL)]) async -> Void
 }
 
 public extension DependencyValues {
@@ -26,56 +28,19 @@ public extension DependencyValues {
 extension ThumbnailCacheClient: DependencyKey {
   public static let liveValue = ThumbnailCacheClient(
     getThumbnail: { fileId, url in
-      let fileManager = FileManager.default
-      guard let cacheDir = thumbnailCacheDirectory() else { return nil }
-
-      let cachedPath = cacheDir.appendingPathComponent("\(fileId).jpg")
-
-      // Check if cached
-      if fileManager.fileExists(atPath: cachedPath.path) {
-        if let data = try? Data(contentsOf: cachedPath),
-           let image = UIImage(data: data)
-        {
-          return image
-        }
-      }
-
-      // Fetch from network
-      do {
-        let (data, response) = try await URLSession.shared.data(from: url)
-
-        guard let httpResponse = response as? HTTPURLResponse,
-              httpResponse.statusCode == 200,
-              let image = UIImage(data: data)
-        else {
-          return nil
-        }
-
-        // Save to cache (use JPEG for smaller file size)
-        if let jpegData = image.jpegData(compressionQuality: 0.8) {
-          try? jpegData.write(to: cachedPath)
-        }
-
-        return image
-      } catch {
-        return nil
-      }
+      await ThumbnailCacheStorage.shared.getImage(fileId: fileId, url: url)
     },
     hasCachedThumbnail: { fileId in
-      guard let cacheDir = thumbnailCacheDirectory() else { return false }
-      let cachedPath = cacheDir.appendingPathComponent("\(fileId).jpg")
-      return FileManager.default.fileExists(atPath: cachedPath.path)
+      await ThumbnailCacheStorage.shared.hasCached(fileId: fileId)
     },
     deleteThumbnail: { fileId in
-      guard let cacheDir = thumbnailCacheDirectory() else { return }
-      let cachedPath = cacheDir.appendingPathComponent("\(fileId).jpg")
-      try? FileManager.default.removeItem(at: cachedPath)
+      await ThumbnailCacheStorage.shared.delete(fileId: fileId)
     },
     clearCache: {
-      guard let cacheDir = thumbnailCacheDirectory() else { return }
-      try? FileManager.default.removeItem(at: cacheDir)
-      // Recreate empty directory
-      try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+      await ThumbnailCacheStorage.shared.clearAll()
+    },
+    prefetchThumbnails: { thumbnails in
+      await ThumbnailCacheStorage.shared.prefetch(thumbnails: thumbnails)
     }
   )
 }
@@ -87,29 +52,159 @@ public extension ThumbnailCacheClient {
     getThumbnail: { _, _ in nil },
     hasCachedThumbnail: { _ in false },
     deleteThumbnail: { _ in },
-    clearCache: {}
+    clearCache: {},
+    prefetchThumbnails: { _ in }
   )
 
   static let previewValue = ThumbnailCacheClient(
     getThumbnail: { _, _ in nil },
     hasCachedThumbnail: { _ in false },
     deleteThumbnail: { _ in },
-    clearCache: {}
+    clearCache: {},
+    prefetchThumbnails: { _ in }
   )
 }
 
-// MARK: - Helpers
+// MARK: - Two-Tier Cache Storage Actor
 
-private func thumbnailCacheDirectory() -> URL? {
-  guard let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-    return nil
+private actor ThumbnailCacheStorage {
+  static let shared = ThumbnailCacheStorage()
+
+  // SAFETY: NSCache is thread-safe internally; actor isolation provides additional safety for access patterns
+  private let memoryCache: NSCache<NSString, UIImage> = {
+    let cache = NSCache<NSString, UIImage>()
+    cache.countLimit = 100
+    cache.totalCostLimit = 50 * 1024 * 1024 // 50MB decoded images
+    return cache
+  }()
+
+  private var inflightTasks: [String: Task<UIImage?, Never>] = [:]
+
+  init() {
+    Self.cleanupOldDirectory()
   }
-  let cacheDir = documentsDir.appendingPathComponent("thumbnails", isDirectory: true)
 
-  // Create directory if needed
-  if !FileManager.default.fileExists(atPath: cacheDir.path) {
-    try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+  // MARK: - Public API
+
+  func getImage(fileId: String, url: URL) async -> UIImage? {
+    // Tier 1: Memory cache (instant)
+    if let cached = memoryCache.object(forKey: fileId as NSString) {
+      return cached
+    }
+
+    // Deduplicate in-flight requests
+    if let existingTask = inflightTasks[fileId] {
+      return await existingTask.value
+    }
+
+    // Tier 2: Disk cache
+    if let diskImage = loadFromDisk(fileId: fileId) {
+      memoryCache.setObject(diskImage, forKey: fileId as NSString)
+      return diskImage
+    }
+
+    // Tier 3: Network fetch with deduplication
+    let task = Task<UIImage?, Never> {
+      do {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200,
+              let image = UIImage(data: data)
+        else { return nil }
+
+        saveToDisk(fileId: fileId, image: image)
+        memoryCache.setObject(image, forKey: fileId as NSString)
+        return image
+      } catch {
+        return nil
+      }
+    }
+
+    inflightTasks[fileId] = task
+    let result = await task.value
+    inflightTasks[fileId] = nil
+    return result
   }
 
-  return cacheDir
+  func hasCached(fileId: String) -> Bool {
+    if memoryCache.object(forKey: fileId as NSString) != nil { return true }
+    return diskFileExists(fileId: fileId)
+  }
+
+  func delete(fileId: String) {
+    memoryCache.removeObject(forKey: fileId as NSString)
+    deleteDiskFile(fileId: fileId)
+  }
+
+  func clearAll() {
+    memoryCache.removeAllObjects()
+    clearDiskCache()
+  }
+
+  func prefetch(thumbnails: [(fileId: String, url: URL)]) async {
+    await withTaskGroup(of: Void.self) { group in
+      for (fileId, url) in thumbnails {
+        group.addTask {
+          _ = await self.getImage(fileId: fileId, url: url)
+        }
+      }
+    }
+  }
+
+  // MARK: - Disk I/O (Library/Caches/thumbnails/)
+
+  private func cacheDirectory() -> URL? {
+    guard let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+    else { return nil }
+    let dir = cachesDir.appendingPathComponent("thumbnails", isDirectory: true)
+    if !FileManager.default.fileExists(atPath: dir.path) {
+      try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+    return dir
+  }
+
+  private func loadFromDisk(fileId: String) -> UIImage? {
+    guard let dir = cacheDirectory() else { return nil }
+    let path = dir.appendingPathComponent("\(fileId).jpg")
+    guard let data = try? Data(contentsOf: path) else { return nil }
+    return UIImage(data: data)
+  }
+
+  private func saveToDisk(fileId: String, image: UIImage) {
+    guard let dir = cacheDirectory() else { return }
+    let path = dir.appendingPathComponent("\(fileId).jpg")
+    if let jpegData = image.jpegData(compressionQuality: 0.8) {
+      try? jpegData.write(to: path)
+    }
+  }
+
+  private func diskFileExists(fileId: String) -> Bool {
+    guard let dir = cacheDirectory() else { return false }
+    let path = dir.appendingPathComponent("\(fileId).jpg")
+    return FileManager.default.fileExists(atPath: path.path)
+  }
+
+  private func deleteDiskFile(fileId: String) {
+    guard let dir = cacheDirectory() else { return }
+    let path = dir.appendingPathComponent("\(fileId).jpg")
+    try? FileManager.default.removeItem(at: path)
+  }
+
+  private func clearDiskCache() {
+    guard let dir = cacheDirectory() else { return }
+    try? FileManager.default.removeItem(at: dir)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  }
+
+  // MARK: - Old Directory Cleanup (Documents/thumbnails/ -> deleted)
+
+  private static func cleanupOldDirectory() {
+    let fileManager = FileManager.default
+    guard let docsDir = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
+    else { return }
+
+    let oldDir = docsDir.appendingPathComponent("thumbnails", isDirectory: true)
+    guard fileManager.fileExists(atPath: oldDir.path) else { return }
+    try? fileManager.removeItem(at: oldDir)
+  }
 }


### PR DESCRIPTION
## Summary
- Handle .accepted (202), .created (201), .noContent (204) from regenerated OpenAPI spec
- Add .serverDownloading Live Activity status with iCloud icon (cyan)
- Show Server downloading status in file cell UI
- Two-tier thumbnail cache: NSCache in-memory + disk in Library/Caches/thumbnails/
- Proactive thumbnail prefetch on all 3 file-arrival paths
- Parse thumbnailUrl from DownloadStartedNotification (was discarded)
- Fix DownloadActivityStatus enum drift between Packages/App/Widget copies

## Test plan
- [x] Build succeeds (pre-push hook verified)
- [x] ThumbnailCacheClient tests pass (5/5)
- [x] E2E: notifications received on device
- [ ] E2E: DownloadReadyNotification triggers device download
- [ ] E2E: Live Activity full transition
- [ ] Verify thumbnail persists across app relaunch