### PR TITLE
fix(concurrency): replace Task.detached with structured alternatives

### DIFF
--- a/App/Features/FileListFeature.swift
+++ b/App/Features/FileListFeature.swift
@@ -114,7 +114,7 @@ struct FileListFeature {
           },
           // Pre-warm pasteboard access (triggers permission dialog if needed)
           .run { _ in
-            _ = await Task.detached(priority: .background) { pasteboard.hasStrings() }.value
+            _ = pasteboard.hasStrings()
           }
         )
 
@@ -292,18 +292,17 @@ struct FileListFeature {
 
       case .addFromClipboard:
         state.showAddConfirmation = false
-        // Move pasteboard access to background thread to avoid blocking main thread (1-3s)
         let pasteboard = pasteboardClient
         return .run { send in
-          let result = await Task.detached {
+          let result: (URL, String?)? = {
             guard pasteboard.hasStrings(),
                   let urlString = pasteboard.string(),
                   let url = URL(string: urlString)
             else {
-              return nil as (URL, String?)?
+              return nil
             }
             return (url, urlString.youtubeID)
-          }.value
+          }()
 
           guard let (url, youtubeId) = result else {
             await send(.showError(.invalidClipboardUrl))

--- a/Packages/OMDFeatures/Sources/FileListFeature/FileListFeature.swift
+++ b/Packages/OMDFeatures/Sources/FileListFeature/FileListFeature.swift
@@ -115,7 +115,7 @@ public struct FileListFeature: Sendable {
             }
           },
           .run { _ in
-            _ = await Task.detached(priority: .background) { pasteboard.hasStrings() }.value
+            _ = pasteboard.hasStrings()
           }
         )
 
@@ -281,15 +281,15 @@ public struct FileListFeature: Sendable {
         state.showAddConfirmation = false
         let pasteboard = pasteboardClient
         return .run { send in
-          let result = await Task.detached {
+          let result: (URL, String?)? = {
             guard pasteboard.hasStrings(),
                   let urlString = pasteboard.string(),
                   let url = URL(string: urlString)
             else {
-              return nil as (URL, String?)?
+              return nil
             }
             return (url, urlString.youtubeID)
-          }.value
+          }()
 
           guard let (url, youtubeId) = result else {
             await send(.showError(.invalidClipboardUrl))


### PR DESCRIPTION
## Summary
- Remove unnecessary `Task.detached` in FileListFeature pasteboard pre-warm and addFromClipboard actions
- Both sites use synchronous `@Sendable` closures inside `.run` effects already on the cooperative thread pool — detaching was unnecessary and broke TCA task-local propagation
- Part of S58 convention rollout (Task.detached requires safety comment)

## Changes
- `FileListFeature.swift` (both App/ and Packages/ copies):
  - Site A (line 116): `Task.detached(priority: .background) { pasteboard.hasStrings() }` → direct `pasteboard.hasStrings()` call
  - Site B (line 273/288): `Task.detached { ... }.value` → synchronous immediately-invoked closure

## Test plan
- [x] `xcodebuild build` passes (verified)
- [x] Grep audit: 0 remaining `Task.detached` in OMD source
- [x] Manual smoke test: Open app, tap "Add from Clipboard" on FileList view, verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)