### PR TITLE
feat(notifications): download progress + 10% throttle + App/ fix

### DIFF
--- a/App/Features/DownloadTrackingFeature.swift
+++ b/App/Features/DownloadTrackingFeature.swift
@@ -55,6 +55,7 @@ struct DownloadTrackingFeature {
             await liveActivityClient.updateProgress(fileId: fileId, percent: 0, status: .downloading)
             let stream = downloadClient.downloadFile(url, size)
             var firstProgressReceived = false
+            var lastReportedPercent = 0
             for await progress in stream {
               switch progress {
               case .completed:
@@ -66,8 +67,12 @@ struct DownloadTrackingFeature {
                   firstProgressReceived = true
                   await send(.firstProgressReceived(fileId: fileId))
                 }
-                await liveActivityClient.updateProgress(fileId: fileId, percent: percent, status: .downloading)
-                await send(.delegate(.downloadProgressUpdated(fileId: fileId, percent: percent)))
+                // Throttle Live Activity and delegate updates to 10% intervals
+                if percent >= lastReportedPercent + 10 || percent >= 100 {
+                  lastReportedPercent = percent
+                  await liveActivityClient.updateProgress(fileId: fileId, percent: percent, status: .downloading)
+                  await send(.delegate(.downloadProgressUpdated(fileId: fileId, percent: percent)))
+                }
               }
             }
           },

--- a/App/Features/FileListFeature.swift
+++ b/App/Features/FileListFeature.swift
@@ -54,6 +54,7 @@ struct FileListFeature {
     case fileAddedFromPush(File)
     case updateFileUrl(fileId: String, url: URL)
     case fileDownloadStartedOnServer(fileId: String, thumbnailUrl: String?)
+    case serverDownloadProgress(fileId: String, percent: Int)
     case refreshFileState(String) // fileId
     case fileFailed(fileId: String, error: String)
     case deleteFileFailed(File, String)
@@ -459,6 +460,12 @@ struct FileListFeature {
           state.files[id: fileId] = fileState
         }
         return .none
+
+      case let .serverDownloadProgress(fileId, percent):
+        let liveActivityClient = liveActivityClient
+        return .run { _ in
+          await liveActivityClient.updateProgress(fileId, percent, .serverDownloading)
+        }
 
       case let .fileDownloadStartedOnServer(fileId, thumbnailUrl):
         if var fileState = state.files[id: fileId] {

--- a/App/Features/RootFeature.swift
+++ b/App/Features/RootFeature.swift
@@ -296,6 +296,9 @@ struct RootFeature {
             }
           )
 
+        case let .downloadProgress(fileId, progressPercent):
+          return .send(.main(.fileList(.serverDownloadProgress(fileId: fileId, percent: progressPercent))))
+
         case let .failure(fileId, _, _, errorMessage):
           // Update file status to failed in CoreData and UI, end Live Activity
           return .run { [coreDataClient, liveActivityClient] send in

--- a/App/Models/PushNotification.swift
+++ b/App/Models/PushNotification.swift
@@ -9,6 +9,8 @@ enum PushNotificationType: Equatable {
   case downloadReady(fileId: String, key: String, url: URL, size: Int64)
   /// Server has started downloading the file to S3
   case downloadStarted(fileId: String, thumbnailUrl: String?, title: String?)
+  /// Server-side download progress update (25/50/75%)
+  case downloadProgress(fileId: String, progressPercent: Int)
   /// File processing failed
   case failure(fileId: String, title: String?, errorCategory: String, errorMessage: String)
   /// Unknown or malformed notification
@@ -56,6 +58,15 @@ enum PushNotificationType: Equatable {
       let thumbnailUrl = fileData["thumbnailUrl"] as? String
       let title = fileData["title"] as? String
       return .downloadStarted(fileId: fileId, thumbnailUrl: thumbnailUrl, title: title)
+
+    case "DownloadProgressNotification":
+      guard let fileId = fileData["fileId"] as? String,
+            let progressPercent = fileData["progressPercent"] as? Int
+      else {
+        logger.warning(.push, "Missing required fields in DownloadProgressNotification")
+        return .unknown
+      }
+      return .downloadProgress(fileId: fileId, progressPercent: progressPercent)
 
     case "FailureNotification":
       guard let fileId = fileData["fileId"] as? String,

--- a/Packages/OMDFeatures/Sources/DownloadTrackingFeature/DownloadTrackingFeature.swift
+++ b/Packages/OMDFeatures/Sources/DownloadTrackingFeature/DownloadTrackingFeature.swift
@@ -69,6 +69,7 @@ public struct DownloadTrackingFeature: Sendable {
             await liveActivityClient.updateProgress(fileId: fileId, percent: 0, status: .downloading)
             let stream = downloadClient.downloadFile(url, size)
             var firstProgressReceived = false
+            var lastReportedPercent = 0
             for await progress in stream {
               switch progress {
               case .completed:
@@ -80,8 +81,12 @@ public struct DownloadTrackingFeature: Sendable {
                   firstProgressReceived = true
                   await send(.firstProgressReceived(fileId: fileId))
                 }
-                await liveActivityClient.updateProgress(fileId: fileId, percent: percent, status: .downloading)
-                await send(.delegate(.downloadProgressUpdated(fileId: fileId, percent: percent)))
+                // Throttle Live Activity and delegate updates to 10% intervals
+                if percent >= lastReportedPercent + 10 || percent >= 100 {
+                  lastReportedPercent = percent
+                  await liveActivityClient.updateProgress(fileId: fileId, percent: percent, status: .downloading)
+                  await send(.delegate(.downloadProgressUpdated(fileId: fileId, percent: percent)))
+                }
               }
             }
           },

--- a/Packages/OMDFeatures/Sources/FileListFeature/FileListFeature.swift
+++ b/Packages/OMDFeatures/Sources/FileListFeature/FileListFeature.swift
@@ -62,6 +62,7 @@ public struct FileListFeature: Sendable {
     case fileAddedFromPush(File)
     case updateFileUrl(fileId: String, url: URL)
     case fileDownloadStartedOnServer(fileId: String, thumbnailUrl: String?)
+    case serverDownloadProgress(fileId: String, percent: Int)
     case refreshFileState(String)
     case fileFailed(fileId: String, error: String)
     case clearAllFiles
@@ -424,6 +425,12 @@ public struct FileListFeature: Sendable {
           state.files[id: fileId] = fileState
         }
         return .none
+
+      case let .serverDownloadProgress(fileId, percent):
+        let liveActivityClient = liveActivityClient
+        return .run { _ in
+          await liveActivityClient.updateProgress(fileId, percent, .serverDownloading)
+        }
 
       case let .refreshFileState(fileId):
         if state.files[id: fileId] != nil {

--- a/Packages/OMDFeatures/Sources/RootFeature/PushNotification.swift
+++ b/Packages/OMDFeatures/Sources/RootFeature/PushNotification.swift
@@ -8,6 +8,7 @@ public enum PushNotificationType: Equatable, Sendable {
   case metadata(File)
   case downloadReady(fileId: String, key: String, url: URL, size: Int64)
   case downloadStarted(fileId: String, thumbnailUrl: String?, title: String?)
+  case downloadProgress(fileId: String, progressPercent: Int)
   case failure(fileId: String, title: String?, errorCategory: String, errorMessage: String)
   case unknown
 
@@ -51,6 +52,15 @@ public enum PushNotificationType: Equatable, Sendable {
       let thumbnailUrl = fileData["thumbnailUrl"] as? String
       let title = fileData["title"] as? String
       return .downloadStarted(fileId: fileId, thumbnailUrl: thumbnailUrl, title: title)
+
+    case "DownloadProgressNotification":
+      guard let fileId = fileData["fileId"] as? String,
+            let progressPercent = fileData["progressPercent"] as? Int
+      else {
+        logger.warning(.push, "Missing required fields in DownloadProgressNotification")
+        return .unknown
+      }
+      return .downloadProgress(fileId: fileId, progressPercent: progressPercent)
 
     case "FailureNotification":
       guard let fileId = fileData["fileId"] as? String,

--- a/Packages/OMDFeatures/Sources/RootFeature/RootFeature.swift
+++ b/Packages/OMDFeatures/Sources/RootFeature/RootFeature.swift
@@ -291,6 +291,9 @@ public struct RootFeature: Sendable {
             }
           )
 
+        case let .downloadProgress(fileId, progressPercent):
+          return .send(.main(.fileList(.serverDownloadProgress(fileId: fileId, percent: progressPercent))))
+
         case let .failure(fileId, _, _, errorMessage):
           return .run { [coreDataClient, liveActivityClient] send in
             await liveActivityClient.endActivity(fileId: fileId, status: .failed, errorMessage: errorMessage)


### PR DESCRIPTION
## Summary

- Adds `.downloadProgress(fileId:progressPercent:)` case to `PushNotificationType`
- Routes through `RootFeature` → `FileListFeature.serverDownloadProgress` → Live Activity update
- Throttles local download progress to 10% intervals (was every 1%)
- Fixes: changes applied to both `App/` (Xcode build target) and `Packages/OMDFeatures/`

## Files changed

**App/ (active build target):**
- `App/Models/PushNotification.swift` — Parser case for `DownloadProgressNotification`
- `App/Features/RootFeature.swift` — Routes `.downloadProgress` to FileListFeature
- `App/Features/FileListFeature.swift` — `.serverDownloadProgress` action + Live Activity
- `App/Features/DownloadTrackingFeature.swift` — 10% throttle for local download progress

**Packages/OMDFeatures/Sources/ (SPM package copy):**
- `RootFeature/PushNotification.swift` — Same parser changes
- `RootFeature/RootFeature.swift` — Same routing
- `FileListFeature/FileListFeature.swift` — Same action + Live Activity
- `DownloadTrackingFeature/DownloadTrackingFeature.swift` — Same 10% throttle

## Companion PR

Backend: j0nathan-ll0yd/mantle-OfflineMediaDownloader#489

## Test plan

- [x] `xcodebuild build` — BUILD SUCCEEDED
- [x] Server progress notifications received at 25/50/75% on device
- [x] Live Activity updates during server-side download (verified on staging)
- [x] Local download progress throttled to 10% intervals

🤖 Generated with [Claude Code](https://claude.com/claude-code)