### PR TITLE
fix(ci): surface release archive errors, run on PRs, fix stale cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -226,7 +226,6 @@ jobs:
 
   release-build:
     name: Release Archive (no codesign)
-    if: github.event_name == 'push'
     needs: lint
     runs-on: macos-15
     timeout-minutes: 30
@@ -238,8 +237,6 @@ jobs:
       - uses: irgaly/xcode-cache@4141f139f00e335c6e1031fb93e667181f86146f  # v1.9.2
         with:
           key: xcode-deriveddata-release-${{ runner.os }}-${{ hashFiles('**/*.pbxproj', '**/Package.resolved') }}
-          restore-keys: |
-            xcode-deriveddata-release-${{ runner.os }}-
 
       - name: Install xcbeautify
         run: brew install xcbeautify
@@ -258,3 +255,19 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             2>&1 | tee release-build.log | xcbeautify
+
+      - name: Archive error summary
+        if: failure()
+        run: |
+          echo "### Release Archive Errors" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -E 'error:' release-build.log | head -50 >> $GITHUB_STEP_SUMMARY || echo "No error: lines found — check the raw log artifact" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload raw build log (failure only)
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-build-log
+          path: release-build.log
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Upload release-build.log as artifact on failure for raw error visibility (xcbeautify swallows whole-module compilation errors)
- Add error summary to GitHub Step Summary on archive failure
- Remove push-only gate so release archive runs on PRs (prevents blind spots)
- Remove restore-keys fallback from DerivedData cache to prevent stale cache restoration

## Context
The Release Archive job failed on master (run 24816508458) with exit code 65, but xcbeautify swallowed all error output during the 10-minute app compilation phase. The archive succeeds locally on Xcode 26.4.1 but fails on CI Xcode 26.3.

Root cause is likely a Release-only compilation error (SWIFT_COMPILATION_MODE=wholemodule + SWIFT_TREAT_WARNINGS_AS_ERRORS=YES) that was never caught pre-merge because the release-build job only ran on push events.

## Test plan
- [ ] CI runs the release-build job on this PR (previously skipped on PRs)
- [ ] If archive fails, the release-build-log artifact is uploaded and error summary appears in Step Summary
- [ ] If archive passes, confirms the stale cache was the root cause
- [ ] Verify no restore-keys fallback in cache config