### PR TITLE
chore: iOS convention compliance (S54-S86)

### DIFF
--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -117,8 +117,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     logger.info(.lifecycle, "AppDelegate: handleEventsForBackgroundURLSession called with identifier: \(identifier)")
     // Re-initialize DownloadManager if needed (it's a singleton, so accessing .shared ensures it's initialized)
     // Pass the completion handler to DownloadManager
+    // SAFETY: completionHandler must escape @MainActor isolation to be called from async context
     nonisolated(unsafe) let handler = completionHandler
-    Task {
+    Task(name: "set-background-completion-handler") {
       await DownloadManager.shared.setBackgroundCompletionHandler(handler)
     }
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+@~/.claude/principles/ios-tca-conventions.md
+
 # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.

--- a/Packages/OMDFeatures/Sources/DefaultFilesFeature/DefaultFilesView.swift
+++ b/Packages/OMDFeatures/Sources/DefaultFilesFeature/DefaultFilesView.swift
@@ -308,9 +308,13 @@ public struct DefaultFilesView: View {
 
   // MARK: - Helpers
 
-  private func formatSize(_ bytes: Int64) -> String {
+  private static let fileSizeFormatter: ByteCountFormatter = {
     let formatter = ByteCountFormatter()
     formatter.countStyle = .file
-    return formatter.string(fromByteCount: bytes)
+    return formatter
+  }()
+
+  private func formatSize(_ bytes: Int64) -> String {
+    Self.fileSizeFormatter.string(fromByteCount: bytes)
   }
 }

--- a/Packages/OMDFeatures/Sources/DiagnosticFeature/DiagnosticView.swift
+++ b/Packages/OMDFeatures/Sources/DiagnosticFeature/DiagnosticView.swift
@@ -213,10 +213,10 @@ public struct DiagnosticView: View {
         .padding(.leading, 4)
 
       VStack(spacing: 0) {
-        ForEach(items.indices, id: \.self) { index in
-          settingsRow(item: items[index])
+        ForEach(items) { item in
+          settingsRow(item: item)
 
-          if index < items.count - 1 {
+          if item.id != items.last?.id {
             Divider()
               .background(DarkProfessionalTheme.divider)
               .padding(.leading, 52)
@@ -411,10 +411,15 @@ public struct DiagnosticView: View {
       .contentShape(Rectangle())
     }
 
-    private func formattedExpiration(_ date: Date) -> String {
+    private static let expirationFormatter: DateFormatter = {
       let formatter = DateFormatter()
       formatter.dateStyle = .medium
       formatter.timeStyle = .short
+      return formatter
+    }()
+
+    private func formattedExpiration(_ date: Date) -> String {
+      let formatter = Self.expirationFormatter
       let timeUntil = date.timeIntervalSinceNow
       if timeUntil < 0 {
         return "Expired: \(formatter.string(from: date))"
@@ -440,10 +445,14 @@ public struct DiagnosticView: View {
 
 // MARK: - Supporting Types
 
-private struct SettingsItem {
+private struct SettingsItem: Identifiable {
   let icon: String
   let title: String
   let color: Color
+
+  var id: String {
+    title
+  }
 }
 
 private struct StatCard: View {
@@ -720,14 +729,18 @@ public struct TokenExpirationDetailView: View {
     .preferredColorScheme(.dark)
   }
 
+  private static let dateTimeFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    formatter.timeStyle = .medium
+    return formatter
+  }()
+
   private var formattedValue: String {
     guard let expiresAt else {
       return "Not set"
     }
-    let formatter = DateFormatter()
-    formatter.dateStyle = .medium
-    formatter.timeStyle = .medium
-    return formatter.string(from: expiresAt)
+    return Self.dateTimeFormatter.string(from: expiresAt)
   }
 
   private var statusColor: Color {

--- a/Packages/OMDFeatures/Sources/FileDetailFeature/FileDetailView.swift
+++ b/Packages/OMDFeatures/Sources/FileDetailFeature/FileDetailView.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import DesignSystem
+import SharedModels
 import SwiftUI
 import ThumbnailCacheClient
 
@@ -321,23 +322,29 @@ public struct FileDetailView: View {
     }
   }
 
-  private func formatFileSize(_ bytes: Int) -> String {
+  private static let fileSizeFormatter: ByteCountFormatter = {
     let formatter = ByteCountFormatter()
     formatter.countStyle = .file
-    return formatter.string(fromByteCount: Int64(bytes))
+    return formatter
+  }()
+
+  private static let mediumDateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    return formatter
+  }()
+
+  private func formatFileSize(_ bytes: Int) -> String {
+    Self.fileSizeFormatter.string(fromByteCount: Int64(bytes))
   }
 
   private func formatDate(_ date: Date) -> String {
-    let formatter = DateFormatter()
-    formatter.dateStyle = .medium
-    return formatter.string(from: date)
+    Self.mediumDateFormatter.string(from: date)
   }
 
   /// Format upload date from YYYYMMDD string
   private func formatUploadDate(_ dateString: String) -> String {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyyMMdd"
-    guard let date = formatter.date(from: dateString) else {
+    guard let date = DateFormatters.yyyyMMdd.date(from: dateString) else {
       return dateString
     }
     return MetadataFormatters.formatRelativeDate(date)

--- a/Packages/OMDFeatures/Sources/LiveActivityClient/LiveActivityManager.swift
+++ b/Packages/OMDFeatures/Sources/LiveActivityClient/LiveActivityManager.swift
@@ -63,8 +63,10 @@ public actor LiveActivityManager {
     state.authorName = authorName
     currentStates[fileId] = state
 
+    // SAFETY: Activity<T> is not Sendable; escaping actor isolation is required to call .update() from async context
     nonisolated(unsafe) let unsafeActivity = activity
-    nonisolated(unsafe) let content = ActivityContent(state: state, staleDate: nil)
+    // SAFETY: ActivityContent is not Sendable; constructed outside actor isolation for use with nonisolated Activity API
+    nonisolated(unsafe) let content = ActivityContent(state: state, staleDate: Date().addingTimeInterval(120))
     await unsafeActivity.update(content)
     liveActivityLog.info("Live Activity metadata updated for fileId: \(fileId), title: \(title)")
   }
@@ -118,8 +120,10 @@ public actor LiveActivityManager {
     state.progressPercent = percent
     currentStates[fileId] = state
 
+    // SAFETY: Activity<T> is not Sendable; escaping actor isolation is required to call .update() from async context
     nonisolated(unsafe) let unsafeActivity = activity
-    nonisolated(unsafe) let content = ActivityContent(state: state, staleDate: nil)
+    // SAFETY: ActivityContent is not Sendable; constructed outside actor isolation for use with nonisolated Activity API
+    nonisolated(unsafe) let content = ActivityContent(state: state, staleDate: Date().addingTimeInterval(120))
     await unsafeActivity.update(content)
     liveActivityLog.debug("Live Activity updated for fileId: \(fileId), progress: \(percent)%, status: \(status.rawValue)")
   }
@@ -136,7 +140,9 @@ public actor LiveActivityManager {
     state.progressPercent = status == .downloaded ? 100 : 0
     state.errorMessage = errorMessage
 
+    // SAFETY: Activity<T> is not Sendable; escaping actor isolation is required to call .update() from async context
     nonisolated(unsafe) let unsafeActivity = activity
+    // SAFETY: ActivityContent is not Sendable; constructed outside actor isolation for use with nonisolated Activity .end() API
     nonisolated(unsafe) let endState = state
     await unsafeActivity.end(ActivityContent(state: endState, staleDate: nil), dismissalPolicy: .default)
     activeActivities[fileId] = nil

--- a/Packages/OMDFeatures/Sources/ServerClient/Environment.swift
+++ b/Packages/OMDFeatures/Sources/ServerClient/Environment.swift
@@ -8,6 +8,7 @@ public enum Environment {
       NSClassFromString("XCTestCase") != nil
   }
 
+  // SAFETY: Bundle.main.infoDictionary is read-only after app launch; static let ensures single initialization
   private nonisolated(unsafe) static let infoDictionary: [String: Any] = // In test environments, Bundle.main.infoDictionary may be nil or missing keys
     Bundle.main.infoDictionary ?? [:]
 


### PR DESCRIPTION
## Summary

- **S72**: Add `// SAFETY:` comments to all 8 `nonisolated(unsafe)` usages (LiveActivityManager ×6, Environment ×1, AppDelegate ×1)
- **S64**: Fix `staleDate: nil` on 2 Live Activity `.update()` calls → `Date().addingTimeInterval(120)` (`.request()` and `.end()` calls exempt)
- **S59**: Extract DateFormatter and ByteCountFormatter allocations from view rendering paths to `private static let` (DiagnosticView ×2, FileDetailView ×3, DefaultFilesView ×1)
- **S60**: Make `SettingsItem` conform to `Identifiable` for stable ForEach IDs in DiagnosticView
- **S56**: Add `Task(name:)` to lifecycle Task in AppDelegate

## Test plan

- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test` passes
- [x] Grep verification: all `nonisolated(unsafe)` have SAFETY comments
- [x] Grep verification: `staleDate: nil` only on `.request()` and `.end()` calls
- [x] Grep verification: no `DateFormatter()` or `ByteCountFormatter()` in non-static methods
- [x] Grep verification: no `ForEach.*indices.*self` in DiagnosticView
- [x] Live Activity displays correctly with stale date timeout