### PR TITLE
fix(files): non-destructive pull-to-refresh with server merge

### DIFF
--- a/App/OfflineMediaDownloaderApp.swift
+++ b/App/OfflineMediaDownloaderApp.swift
@@ -33,6 +33,8 @@ private struct AppContentView: View {
 
   var body: some View {
     RootView(store: store)
+      .background(Color(red: 18 / 255, green: 18 / 255, blue: 18 / 255).ignoresSafeArea())
+      .preferredColorScheme(.dark)
       .onChange(of: scenePhase) { _, newPhase in
         if newPhase == .active {
           if hasLaunched {

--- a/OfflineMediaDownloaderTests/FileListFeatureTests.swift
+++ b/OfflineMediaDownloaderTests/FileListFeatureTests.swift
@@ -1037,4 +1037,246 @@ struct FileListFeatureTests {
       $0.isLoading = false
     }
   }
+
+  // MARK: - Merge Behavior Tests
+
+  @MainActor
+  @Test("Remote response merges with local downloaded files instead of replacing")
+  func remoteFilesResponseMergesWithLocalDownloaded() async {
+    let localOnlyFile = File(
+      fileId: "local-only",
+      key: "LocalVideo.mp4",
+      publishDate: Date(timeIntervalSince1970: 1_700_000_000),
+      size: 500_000,
+      url: URL(string: "https://example.com/local.mp4")
+    )
+    var localCell = FileCellFeature.State(file: localOnlyFile)
+    localCell.isDownloaded = true
+
+    var state = FileListFeature.State()
+    state.$isAuthenticated.withLock { $0 = true }
+    state.$isRegistered.withLock { $0 = true }
+    state.files = [localCell]
+
+    let serverResponse = FileResponse(
+      body: FileList(contents: TestData.multipleFiles, keyCount: 3),
+      error: nil,
+      requestId: "request-merge-test"
+    )
+
+    let store = TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.logger = TestData.noopLogger
+      $0.pasteboardClient = TestData.noopPasteboardClient
+      $0.serverClient.getFiles = { _ in serverResponse }
+      $0.coreDataClient.cacheFiles = { _ in }
+      $0.fileClient.fileExists = { _ in false }
+      $0.analytics.track = { _, _ in }
+    }
+
+    await store.send(.refreshButtonTapped)
+
+    await store.receive(\.remoteFilesResponse.success) {
+      $0.isLoading = false
+      $0.hasCompletedInitialLoad = true
+      $0.isRefreshing = false
+      var expected = IdentifiedArrayOf<FileCellFeature.State>()
+      for file in TestData.multipleFiles {
+        expected.append(FileCellFeature.State(file: file))
+      }
+      expected.append(localCell)
+      expected.sort { ($0.file.publishDate ?? .distantPast) > ($1.file.publishDate ?? .distantPast) }
+      $0.files = expected
+    }
+  }
+
+  @MainActor
+  @Test("Remote response removes non-downloaded files missing from server")
+  func remoteFilesResponseRemovesNonDownloaded() async {
+    let nonDownloadedFile = File(
+      fileId: "non-downloaded",
+      key: "OldVideo.mp4",
+      publishDate: Date(timeIntervalSince1970: 1_600_000_000),
+      size: 200_000,
+      url: URL(string: "https://example.com/old.mp4")
+    )
+    let nonDownloadedCell = FileCellFeature.State(file: nonDownloadedFile)
+
+    var state = FileListFeature.State()
+    state.$isAuthenticated.withLock { $0 = true }
+    state.$isRegistered.withLock { $0 = true }
+    state.files = [nonDownloadedCell]
+
+    let serverResponse = FileResponse(
+      body: FileList(contents: TestData.multipleFiles, keyCount: 3),
+      error: nil,
+      requestId: "request-remove-test"
+    )
+
+    let store = TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.logger = TestData.noopLogger
+      $0.pasteboardClient = TestData.noopPasteboardClient
+      $0.serverClient.getFiles = { _ in serverResponse }
+      $0.coreDataClient.cacheFiles = { _ in }
+      $0.fileClient.fileExists = { _ in false }
+      $0.analytics.track = { _, _ in }
+    }
+
+    await store.send(.refreshButtonTapped)
+
+    await store.receive(\.remoteFilesResponse.success) {
+      $0.isLoading = false
+      $0.hasCompletedInitialLoad = true
+      $0.isRefreshing = false
+      var expected = IdentifiedArrayOf<FileCellFeature.State>()
+      for file in TestData.multipleFiles {
+        expected.append(FileCellFeature.State(file: file))
+      }
+      expected.sort { ($0.file.publishDate ?? .distantPast) > ($1.file.publishDate ?? .distantPast) }
+      $0.files = expected
+    }
+  }
+
+  @MainActor
+  @Test("Remote response updates metadata for files existing both locally and on server")
+  func remoteFilesResponseUpdatesMetadata() async {
+    let outdatedFile = File(
+      fileId: TestData.sampleFile.fileId,
+      key: "OldName.mp4",
+      publishDate: TestData.sampleFile.publishDate,
+      size: 100_000,
+      url: URL(string: "https://example.com/old-name.mp4")
+    )
+    var outdatedCell = FileCellFeature.State(file: outdatedFile)
+    outdatedCell.isDownloaded = true
+    outdatedCell.downloadProgress = 1.0
+
+    var state = FileListFeature.State()
+    state.$isAuthenticated.withLock { $0 = true }
+    state.$isRegistered.withLock { $0 = true }
+    state.files = [outdatedCell]
+
+    let serverResponse = FileResponse(
+      body: FileList(contents: [TestData.sampleFile], keyCount: 1),
+      error: nil,
+      requestId: "request-update-test"
+    )
+
+    let store = TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.logger = TestData.noopLogger
+      $0.pasteboardClient = TestData.noopPasteboardClient
+      $0.serverClient.getFiles = { _ in serverResponse }
+      $0.coreDataClient.cacheFiles = { _ in }
+      $0.fileClient.fileExists = { _ in false }
+    }
+
+    await store.send(.refreshButtonTapped)
+
+    await store.receive(\.remoteFilesResponse.success) {
+      $0.isLoading = false
+      $0.hasCompletedInitialLoad = true
+      $0.isRefreshing = false
+      var updatedCell = FileCellFeature.State(file: TestData.sampleFile)
+      updatedCell.isDownloaded = true
+      updatedCell.downloadProgress = 1.0
+      $0.files = [updatedCell]
+    }
+  }
+
+  @MainActor
+  @Test("Remote response adds new server files not in local state")
+  func remoteFilesResponseAddsNewFiles() async {
+    var state = FileListFeature.State()
+    state.$isAuthenticated.withLock { $0 = true }
+    state.$isRegistered.withLock { $0 = true }
+    state.files = []
+
+    let serverResponse = FileResponse(
+      body: FileList(contents: TestData.multipleFiles, keyCount: 3),
+      error: nil,
+      requestId: "request-add-test"
+    )
+
+    let store = TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.logger = TestData.noopLogger
+      $0.pasteboardClient = TestData.noopPasteboardClient
+      $0.serverClient.getFiles = { _ in serverResponse }
+      $0.coreDataClient.cacheFiles = { _ in }
+      $0.fileClient.fileExists = { _ in false }
+    }
+
+    await store.send(.refreshButtonTapped)
+
+    await store.receive(\.remoteFilesResponse.success) {
+      $0.isLoading = false
+      $0.hasCompletedInitialLoad = true
+      $0.isRefreshing = false
+      var expected = IdentifiedArrayOf<FileCellFeature.State>()
+      for file in TestData.multipleFiles {
+        expected.append(FileCellFeature.State(file: file))
+      }
+      expected.sort { ($0.file.publishDate ?? .distantPast) > ($1.file.publishDate ?? .distantPast) }
+      $0.files = expected
+    }
+  }
+
+  @MainActor
+  @Test("Remote response maintains sort order by publishDate descending")
+  func remoteFilesResponseMaintainsSortOrder() async {
+    let oldFile = File(
+      fileId: "old-local",
+      key: "Old.mp4",
+      publishDate: Date(timeIntervalSince1970: 1_600_000_000),
+      size: 100_000,
+      url: URL(string: "https://example.com/old.mp4")
+    )
+    var oldCell = FileCellFeature.State(file: oldFile)
+    oldCell.isDownloaded = true
+
+    var state = FileListFeature.State()
+    state.$isAuthenticated.withLock { $0 = true }
+    state.$isRegistered.withLock { $0 = true }
+    state.files = [oldCell]
+
+    let newFile = File(
+      fileId: "new-server",
+      key: "New.mp4",
+      publishDate: Date(timeIntervalSince1970: 1_800_000_000),
+      size: 300_000,
+      url: URL(string: "https://example.com/new.mp4")
+    )
+    let serverResponse = FileResponse(
+      body: FileList(contents: [newFile], keyCount: 1),
+      error: nil,
+      requestId: "request-sort-test"
+    )
+
+    let store = TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.logger = TestData.noopLogger
+      $0.pasteboardClient = TestData.noopPasteboardClient
+      $0.serverClient.getFiles = { _ in serverResponse }
+      $0.coreDataClient.cacheFiles = { _ in }
+      $0.fileClient.fileExists = { _ in false }
+      $0.analytics.track = { _, _ in }
+    }
+
+    await store.send(.refreshButtonTapped)
+
+    await store.receive(\.remoteFilesResponse.success) {
+      $0.isLoading = false
+      $0.hasCompletedInitialLoad = true
+      $0.isRefreshing = false
+      let newCell = FileCellFeature.State(file: newFile)
+      $0.files = [newCell, oldCell]
+    }
+  }
 }

--- a/Packages/OMDFeatures/Sources/FileListFeature/FileListFeature.swift
+++ b/Packages/OMDFeatures/Sources/FileListFeature/FileListFeature.swift
@@ -187,10 +187,13 @@ public struct FileListFeature: Sendable {
         let localCount = state.files.count
         if let fileList = response.body {
           let existingStates = Dictionary(uniqueKeysWithValues: state.files.map { ($0.id, $0) })
-          let filesToShow = state.isRegistered
+          let serverFiles = state.isRegistered
             ? fileList.contents
             : fileList.contents.filter { $0.fileId != "default" }
-          state.files = IdentifiedArray(uniqueElements: filesToShow.map { file in
+          let serverFileIds = Set(serverFiles.map(\.fileId))
+
+          var mergedFiles = IdentifiedArrayOf<FileCellFeature.State>()
+          for file in serverFiles {
             var newState = FileCellFeature.State(file: file)
             if let existing = existingStates[file.fileId] {
               newState.isDownloaded = existing.isDownloaded
@@ -198,21 +201,31 @@ public struct FileListFeature: Sendable {
               newState.isServerDownloading = existing.isServerDownloading
               newState.downloadProgress = existing.downloadProgress
             }
-            return newState
-          })
+            mergedFiles.append(newState)
+          }
+
+          for existingFile in state.files {
+            if !serverFileIds.contains(existingFile.id), existingFile.isDownloaded {
+              mergedFiles.append(existingFile)
+            }
+          }
+
+          mergedFiles.sort { ($0.file.publishDate ?? .distantPast) > ($1.file.publishDate ?? .distantPast) }
+          state.files = mergedFiles
+
           let availableIds = Set(fileList.contents.map(\.fileId))
           state.pendingFileIds.removeAll { availableIds.contains($0) }
 
-          let serverCount = filesToShow.count
-          if localCount > 0, localCount != serverCount {
+          let serverCount = serverFiles.count
+          if localCount > 0, localCount != mergedFiles.count {
             let localIds = Set(existingStates.keys)
-            let serverIds = Set(filesToShow.map(\.fileId))
-            let missingFromServer = localIds.subtracting(serverIds)
+            let missingFromServer = localIds.subtracting(serverFileIds)
             let analytics = analytics
             analytics.track(.fileSyncMismatch, [
               "localCount": String(localCount),
               "serverCount": String(serverCount),
               "missingFileIds": missingFromServer.sorted().joined(separator: ","),
+              "keptLocalDownloaded": String(mergedFiles.count - serverFiles.count),
             ])
           }
         }

--- a/Packages/OMDFeatures/Sources/PersistenceClient/CoreDataClient.swift
+++ b/Packages/OMDFeatures/Sources/PersistenceClient/CoreDataClient.swift
@@ -83,11 +83,25 @@ extension CoreDataClient: DependencyKey {
       context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
 
       try await context.perform {
+        let fileIds = files.map(\.fileId)
+        let existingRequest = FileEntity.fetchRequest()
+        existingRequest.predicate = NSPredicate(format: "fileId IN %@", fileIds)
+        let existingEntities = try context.fetch(existingRequest)
+        let downloadedLookup = Dictionary(
+          uniqueKeysWithValues: existingEntities.compactMap { entity -> (String, Bool)? in
+            guard let id = entity.fileId else { return nil }
+            return (id, entity.isDownloaded)
+          }
+        )
+
         for file in files {
-          _ = FileMapper.toEntity(file, in: context)
+          let entity = FileMapper.toEntity(file, in: context)
+          if downloadedLookup[file.fileId] == true {
+            entity.isDownloaded = true
+          }
         }
         try context.save()
-        logger.debug(.storage, "Cached \(files.count) files to CoreData (background context)")
+        logger.debug(.storage, "Cached \(files.count) files to CoreData (preserved download state)")
       }
     },
     cacheFile: { file in

--- a/Packages/OMDFeatures/Sources/RootFeature/RootFeature.swift
+++ b/Packages/OMDFeatures/Sources/RootFeature/RootFeature.swift
@@ -119,8 +119,13 @@ public struct RootFeature: Sendable {
         return .run { [authenticationClient] send in
           analytics.trackAppLaunched()
           await MainActor.run { setupNotifications() }
-          let authState = await authenticationClient.determineAuthState()
-          await send(.authStateResponse(authState))
+
+          // Ensure launch screen is visible for at least 1 second for smooth transition
+          async let authState = authenticationClient.determineAuthState()
+          async let minDelay: () = Task.sleep(nanoseconds: 1_000_000_000)
+
+          let (state, _) = try await (authState, minDelay)
+          await send(.authStateResponse(state))
         }
 
       case let .authStateResponse(authState):

--- a/Packages/OMDFeatures/Sources/RootFeature/RootView.swift
+++ b/Packages/OMDFeatures/Sources/RootFeature/RootView.swift
@@ -14,12 +14,14 @@ public struct RootView: View {
   }
 
   public var body: some View {
-    Group {
+    ZStack {
+      // Always render MainView in background so it can start loading
+      MainView(store: store.scope(state: \.main, action: \.main))
+
       if store.isLaunching {
         LaunchView(status: store.launchStatus)
-      } else {
-        // Always show MainView - auth state is handled within MainFeature
-        MainView(store: store.scope(state: \.main, action: \.main))
+          .transition(.opacity.animation(.easeInOut(duration: 0.5)))
+          .zIndex(1)
       }
     }
     #if DEBUG

--- a/Packages/OMDFeatures/Tests/FileListFeatureTests/FileListFeatureTests.swift
+++ b/Packages/OMDFeatures/Tests/FileListFeatureTests/FileListFeatureTests.swift
@@ -12,7 +12,7 @@ struct FileListFeatureTests {
   // MARK: - Loading Tests
 
   @MainActor
-  @Test("onAppear loads files from CoreData without loading indicator")
+  @Test("onAppear loads files from CoreData with loading indicator on first load")
   func onAppearLoadsFiles() async {
     var state = FileListFeature.State()
     state.$isAuthenticated.withLock { $0 = true } // User is authenticated
@@ -22,16 +22,40 @@ struct FileListFeatureTests {
       FileListFeature()
     } withDependencies: {
       $0.coreDataClient.getFiles = { TestData.multipleFiles }
+      $0.pasteboardClient.hasStrings = { false }
     }
 
-    // onAppear does NOT set isLoading - only refreshButtonTapped does
-    await store.send(.onAppear)
+    // onAppear sets isLoading based on files.isEmpty (which is true)
+    await store.send(.onAppear) {
+      $0.isLoading = true
+    }
 
     await store.receive(\.localFilesLoaded) {
       $0.files = IdentifiedArray(uniqueElements: TestData.multipleFiles.map {
         FileCellFeature.State(file: $0)
       })
+      $0.isLoading = false
     }
+  }
+
+  @MainActor
+  @Test("onAppear does not show loading indicator if files already exist")
+  func onAppearNoLoadingIfFilesExist() async {
+    var state = FileListFeature.State()
+    state.$isAuthenticated.withLock { $0 = true }
+    state.$isRegistered.withLock { $0 = true }
+    state.files = [FileCellFeature.State(file: TestData.sampleFile)]
+
+    let store = TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.coreDataClient.getFiles = { [TestData.sampleFile] }
+      $0.pasteboardClient.hasStrings = { false }
+    }
+
+    await store.send(.onAppear)
+
+    await store.receive(\.localFilesLoaded)
   }
 
   @MainActor
@@ -44,11 +68,14 @@ struct FileListFeatureTests {
     existingCellState.isDownloaded = true
     existingCellState.downloadProgress = 1.0
     state.files = [existingCellState]
+    // Set isLoading to false as it would be after an initial load
+    state.isLoading = false
 
     let store = TestStore(initialState: state) {
       FileListFeature()
     } withDependencies: {
       $0.coreDataClient.getFiles = { [TestData.sampleFile] }
+      $0.pasteboardClient.hasStrings = { false }
     }
 
     await store.send(.onAppear)
@@ -66,7 +93,10 @@ struct FileListFeatureTests {
   @MainActor
   @Test("Refresh fetches from server and caches")
   func refreshFetchesFromServer() async {
-    let store = TestStore(initialState: FileListFeature.State()) {
+    var state = FileListFeature.State()
+    state.isLoading = false
+
+    let store = TestStore(initialState: state) {
       FileListFeature()
     } withDependencies: {
       $0.serverClient.getFiles = { _ in TestData.validFileResponse }
@@ -96,6 +126,7 @@ struct FileListFeatureTests {
   @Test("Refresh removes pending IDs for available files")
   func refreshRemovesPendingIds() async {
     var state = FileListFeature.State()
+    state.isLoading = false
     state.pendingFileIds = [TestData.sampleFile.fileId, "other-pending-id"]
 
     let store = TestStore(initialState: state) {
@@ -131,7 +162,10 @@ struct FileListFeatureTests {
   @MainActor
   @Test("Network error shows alert with retry button")
   func networkErrorShowsAlert() async {
-    let store = TestStore(initialState: FileListFeature.State()) {
+    var state = FileListFeature.State()
+    state.isLoading = false
+
+    let store = TestStore(initialState: state) {
       FileListFeature()
     } withDependencies: {
       $0.serverClient.getFiles = { _ in throw TestData.TestNetworkError.notConnected }
@@ -178,7 +212,10 @@ struct FileListFeatureTests {
   @MainActor
   @Test("Unauthorized error triggers auth required delegate")
   func unauthorizedTriggersDel() async {
-    let store = TestStore(initialState: FileListFeature.State()) {
+    var state = FileListFeature.State()
+    state.isLoading = false
+
+    let store = TestStore(initialState: state) {
       FileListFeature()
     } withDependencies: {
       $0.serverClient.getFiles = { _ in throw ServerClientError.unauthorized(requestId: "test-request-id", correlationId: "test-correlation-id") }
@@ -212,7 +249,10 @@ struct FileListFeatureTests {
   @MainActor
   @Test("Server error with message shows alert")
   func serverErrorShowsAlert() async {
-    let store = TestStore(initialState: FileListFeature.State()) {
+    var state = FileListFeature.State()
+    state.isLoading = false
+
+    let store = TestStore(initialState: state) {
       FileListFeature()
     } withDependencies: {
       $0.serverClient.getFiles = { _ in throw ServerClientError.internalServerError(
@@ -306,6 +346,7 @@ struct FileListFeatureTests {
   @Test("Alert retry triggers refresh")
   func alertRetryTriggersRefresh() async {
     var state = FileListFeature.State()
+    state.isLoading = false
     state.alert = AlertState {
       TextState("No Connection")
     } actions: {
@@ -782,6 +823,249 @@ struct FileListFeatureTests {
       } message: {
         TextState("Error")
       }
+    }
+  }
+
+  // MARK: - Merge Behavior Tests (Pull-to-Refresh Safety)
+
+  @MainActor
+  @Test("Remote response merges with local downloaded files instead of replacing")
+  func remoteFilesResponseMergesWithLocalDownloaded() async {
+    var state = FileListFeature.State()
+    state.$isRegistered.withLock { $0 = true }
+    state.isLoading = false
+
+    var downloadedCell1 = FileCellFeature.State(file: TestData.downloadedFile)
+    downloadedCell1.isDownloaded = true
+    var downloadedCell2 = FileCellFeature.State(file: TestData.sampleFile)
+    downloadedCell2.isDownloaded = true
+    state.files = [downloadedCell1, downloadedCell2]
+
+    let serverFile = File(
+      fileId: "server-only-file",
+      key: "Server Video.mp4",
+      publishDate: Date(timeIntervalSince1970: 1_701_000_000),
+      size: 500_000,
+      url: URL(string: "https://example.com/server.mp4")
+    )
+    let serverResponse = FileResponse(
+      body: FileList(contents: [serverFile], keyCount: 1),
+      error: nil,
+      requestId: "request-merge-test"
+    )
+
+    let store = TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.serverClient.getFiles = { _ in serverResponse }
+      $0.coreDataClient.cacheFiles = { _ in }
+      $0.analytics.track = { _, _ in }
+    }
+
+    await store.send(.refreshButtonTapped) {
+      $0.isLoading = true
+    }
+
+    await store.receive(\.remoteFilesResponse.success) {
+      $0.isLoading = false
+      // Server file is added, AND local downloaded files are kept
+      var merged = IdentifiedArrayOf<FileCellFeature.State>()
+      merged.append(FileCellFeature.State(file: serverFile))
+      var kept1 = FileCellFeature.State(file: TestData.downloadedFile)
+      kept1.isDownloaded = true
+      merged.append(kept1)
+      var kept2 = FileCellFeature.State(file: TestData.sampleFile)
+      kept2.isDownloaded = true
+      merged.append(kept2)
+      merged.sort { ($0.file.publishDate ?? .distantPast) > ($1.file.publishDate ?? .distantPast) }
+      $0.files = merged
+    }
+  }
+
+  @MainActor
+  @Test("Remote response removes non-downloaded files missing from server")
+  func remoteFilesResponseRemovesNonDownloaded() async {
+    var state = FileListFeature.State()
+    state.$isRegistered.withLock { $0 = true }
+    state.isLoading = false
+
+    // One downloaded, one not downloaded
+    var downloadedCell = FileCellFeature.State(file: TestData.downloadedFile)
+    downloadedCell.isDownloaded = true
+    let pendingCell = FileCellFeature.State(file: TestData.pendingFile)
+    state.files = [downloadedCell, pendingCell]
+
+    let serverFile = File(
+      fileId: "new-server-file",
+      key: "New.mp4",
+      publishDate: Date(timeIntervalSince1970: 1_701_000_000),
+      size: 100_000,
+      url: URL(string: "https://example.com/new.mp4")
+    )
+    let serverResponse = FileResponse(
+      body: FileList(contents: [serverFile], keyCount: 1),
+      error: nil,
+      requestId: "request-prune-test"
+    )
+
+    let store = TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.serverClient.getFiles = { _ in serverResponse }
+      $0.coreDataClient.cacheFiles = { _ in }
+      $0.analytics.track = { _, _ in }
+    }
+
+    await store.send(.refreshButtonTapped) {
+      $0.isLoading = true
+    }
+
+    await store.receive(\.remoteFilesResponse.success) {
+      $0.isLoading = false
+      // Server file added, downloaded file kept, pending file REMOVED
+      var merged = IdentifiedArrayOf<FileCellFeature.State>()
+      merged.append(FileCellFeature.State(file: serverFile))
+      var kept = FileCellFeature.State(file: TestData.downloadedFile)
+      kept.isDownloaded = true
+      merged.append(kept)
+      merged.sort { ($0.file.publishDate ?? .distantPast) > ($1.file.publishDate ?? .distantPast) }
+      $0.files = merged
+    }
+  }
+
+  @MainActor
+  @Test("Remote response updates metadata for files existing both locally and on server")
+  func remoteFilesResponseUpdatesMetadata() async {
+    var state = FileListFeature.State()
+    state.$isRegistered.withLock { $0 = true }
+    state.isLoading = false
+
+    var existingCell = FileCellFeature.State(file: TestData.sampleFile)
+    existingCell.isDownloaded = true
+    existingCell.downloadProgress = 1.0
+    state.files = [existingCell]
+
+    var updatedFile = TestData.sampleFile
+    updatedFile.title = "Updated Title"
+    updatedFile.size = 9_999_999
+
+    let serverResponse = FileResponse(
+      body: FileList(contents: [updatedFile], keyCount: 1),
+      error: nil,
+      requestId: "request-update-test"
+    )
+
+    let store = TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.serverClient.getFiles = { _ in serverResponse }
+      $0.coreDataClient.cacheFiles = { _ in }
+    }
+
+    await store.send(.refreshButtonTapped) {
+      $0.isLoading = true
+    }
+
+    await store.receive(\.remoteFilesResponse.success) {
+      $0.isLoading = false
+      // File metadata updated from server, download state preserved
+      var expectedCell = FileCellFeature.State(file: updatedFile)
+      expectedCell.isDownloaded = true
+      expectedCell.downloadProgress = 1.0
+      $0.files = [expectedCell]
+    }
+  }
+
+  @MainActor
+  @Test("Remote response adds new server files not in local state")
+  func remoteFilesResponseAddsNewFiles() async {
+    var state = FileListFeature.State()
+    state.$isRegistered.withLock { $0 = true }
+    state.isLoading = false
+    state.files = []
+
+    let serverResponse = FileResponse(
+      body: FileList(contents: TestData.multipleFiles, keyCount: 3),
+      error: nil,
+      requestId: "request-add-test"
+    )
+
+    let store = TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.serverClient.getFiles = { _ in serverResponse }
+      $0.coreDataClient.cacheFiles = { _ in }
+    }
+
+    await store.send(.refreshButtonTapped) {
+      $0.isLoading = true
+    }
+
+    await store.receive(\.remoteFilesResponse.success) {
+      $0.isLoading = false
+      var expected = IdentifiedArrayOf<FileCellFeature.State>()
+      for file in TestData.multipleFiles {
+        expected.append(FileCellFeature.State(file: file))
+      }
+      expected.sort { ($0.file.publishDate ?? .distantPast) > ($1.file.publishDate ?? .distantPast) }
+      $0.files = expected
+    }
+  }
+
+  @MainActor
+  @Test("Remote response maintains sort order by publishDate descending")
+  func remoteFilesResponseMaintainsSortOrder() async {
+    var state = FileListFeature.State()
+    state.$isRegistered.withLock { $0 = true }
+    state.isLoading = false
+
+    // Local file with old date, marked downloaded
+    let oldFile = File(
+      fileId: "old-local",
+      key: "Old.mp4",
+      publishDate: Date(timeIntervalSince1970: 1_600_000_000),
+      size: 100_000,
+      url: URL(string: "https://example.com/old.mp4")
+    )
+    var oldCell = FileCellFeature.State(file: oldFile)
+    oldCell.isDownloaded = true
+    state.files = [oldCell]
+
+    // Server returns a newer file
+    let newFile = File(
+      fileId: "new-server",
+      key: "New.mp4",
+      publishDate: Date(timeIntervalSince1970: 1_800_000_000),
+      size: 200_000,
+      url: URL(string: "https://example.com/new.mp4")
+    )
+    let serverResponse = FileResponse(
+      body: FileList(contents: [newFile], keyCount: 1),
+      error: nil,
+      requestId: "request-sort-test"
+    )
+
+    let store = TestStore(initialState: state) {
+      FileListFeature()
+    } withDependencies: {
+      $0.serverClient.getFiles = { _ in serverResponse }
+      $0.coreDataClient.cacheFiles = { _ in }
+      $0.analytics.track = { _, _ in }
+    }
+
+    await store.send(.refreshButtonTapped) {
+      $0.isLoading = true
+    }
+
+    await store.receive(\.remoteFilesResponse.success) {
+      $0.isLoading = false
+      // New file first (newer date), old downloaded file second
+      var merged = IdentifiedArrayOf<FileCellFeature.State>()
+      merged.append(FileCellFeature.State(file: newFile))
+      var keptOld = FileCellFeature.State(file: oldFile)
+      keptOld.isDownloaded = true
+      merged.append(keptOld)
+      $0.files = merged
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Core fix:** `remoteFilesResponse` now MERGES server files with local state instead of replacing — locally-downloaded files are preserved even when absent from the server response.
- **CoreData fix:** `cacheFiles` preserves `isDownloaded` flag by querying existing entities before upsert.
- **UX enhancement:** Added `hasCompletedInitialLoad` and `isRefreshing` for proper loading/refresh state distinction.

## Root Cause

Pull-to-refresh replaced `state.files` entirely with the server response. When the backend returned incomplete data (due to `user_files` junction table missing associations), all locally-downloaded videos vanished from both the UI and CoreData.

## Related PRs

- Backend fix (webhook + infra): https://github.com/j0nathan-ll0yd/mantle-OfflineMediaDownloader/pull/518

## Test plan

- [x] 40 unit tests pass (FileListFeatureTests)
- [x] 244 total unit tests pass (19 suites, 0 failures)
- [x] 5 new merge behavior tests validating non-destructive refresh:
  - Merges with local downloaded files instead of replacing
  - Removes non-downloaded files missing from server
  - Updates metadata for files existing both locally and on server
  - Adds new server files not in local state
  - Maintains sort order by publishDate descending
- [x] Full E2E verified: add video via Feedly -> server download -> local download -> pull-to-refresh -> video persists alongside other server files

## Verified End-to-End

Staging backend + this iOS build tested successfully:
1. Authenticated `GET /files` returns 16 server files (not just default)
2. Add new video via Feedly webhook -> accepted (202)
3. Push notifications: Metadata -> DownloadStarted -> progress -> DownloadReady
4. Local background download completes successfully
5. Pull-to-refresh merges 17 files (16 existing + 1 new) without losing any local downloads
