### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs (supply-chain hardening)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: [self-hosted, linux, arm64, swift-lint]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Validate iOS version targets
         run: bash Scripts/validate-ios-version.sh
@@ -98,7 +98,7 @@ jobs:
     runs-on: [self-hosted, macOS, arm64, xcode-26]
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: ./.github/actions/setup-xcode-env
       - name: Build APITypes package
         run: xcrun swift build --package-path APITypes --disable-sandbox
@@ -111,7 +111,7 @@ jobs:
     env:
       SNAPSHOT_TESTING_RECORD: never
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Clone design-system-Lifegames as sibling of workspace
         env:
@@ -215,7 +215,7 @@ jobs:
 
       - name: Upload test results (always)
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-results
           path: |
@@ -226,7 +226,7 @@ jobs:
 
       - name: Upload snapshot failures (failure only)
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: snapshot-failures
           path: |
@@ -260,7 +260,7 @@ jobs:
     runs-on: [self-hosted, macOS, arm64, xcode-26]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Clone design-system-Lifegames as sibling of workspace
         env:
@@ -322,7 +322,7 @@ jobs:
 
       - name: Upload raw build log (failure only)
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-build-log
           path: release-build.log
@@ -333,9 +333,9 @@ jobs:
     runs-on: [self-hosted, macOS, arm64, xcode-26]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 


### PR DESCRIPTION
## What

Pins every GitHub Actions `uses:` reference in this repo's workflows to a full-length commit SHA, each with a trailing `# <version>` comment so the human-readable version stays visible (and Dependabot can bump it). Behavior-preserving — each tag was pinned to the commit it currently resolves to.

## Why

Supply-chain hardening. A tag like `@v7` is mutable: if an action's tag is repointed to malicious code (the `tj-actions/changed-files` class of attack, March 2025), it runs with this workflow's token and secrets and can exfiltrate them straight through the build log with **zero network egress** — which runner VM/container/egress isolation cannot prevent. A commit SHA is immutable, so this is the one supply-chain vector the self-hosted infrastructure can't otherwise close.

Surfaced by the new `ci/action-sha-pins` audit check in `ci-runners-private`, which flagged these refs across all repos.

## Follow-up

Consider enabling Dependabot for `github-actions` (`.github/dependabot.yml`) to keep the SHA pins current as new versions ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
