### PR TITLE
chore: provision fresh git worktrees

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Seed a newly-created linked worktree. Do not run on ordinary branch switches.
+[ "$3" = "1" ] || exit 0
+[ "$1" = "0000000000000000000000000000000000000000" ] || exit 0
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] || exit 0
+
+setup="$(git rev-parse --show-toplevel)/Scripts/worktree-setup.sh"
+[ -x "$setup" ] && "$setup"
+exit 0

--- a/OfflineMediaDownloaderTests/EventBufferTests.swift
+++ b/OfflineMediaDownloaderTests/EventBufferTests.swift
@@ -159,7 +159,9 @@ struct EventBufferTests {
           count += 1
           return count
         }
-        if count <= EventBuffer.maxRetries { throw URLError(.notConnectedToInternet) }
+        if count <= EventBuffer.maxRetries {
+          throw URLError(.notConnectedToInternet)
+        }
       },
       logHandler: { msg in logMessages.withValue { $0.append(msg) } }
     )
@@ -176,47 +178,25 @@ struct EventBufferTests {
 
   @Test("Re-enqueue exceeding cap drops oldest overflow and logs the count")
   func capExceededDropsOldestAndLogs() async {
-    // Strategy: first flush re-enqueues N events (N < 50, no auto-flush). Then we append
-    // enough additional events so the second flush's re-enqueue attempt sees combined > cap
-    // and logs a drop. To keep all appends below the auto-flush threshold (50 per append
-    // session), we build up to cap+overflow across two controlled flushes:
-    //
-    //   Round 1: append 49, flush → fail → re-enqueue 49 (49 ≤ 200, no drop)
-    //   Append 49 more (49 < 50 threshold, no auto-flush) → buffer has 49+49 = 98
-    //   Round 2: flush snapshots 98, fails → re-enqueue: combined = 98 + 0 = 98 (still ≤ 200)
-    //
-    // 200-cap needs combined > 200. 4 rounds of 49 = 196 — still under cap.
-    // Use 5 rounds: 5 × 49 = 245 > 200. Drop = 245 − 200 = 45 events.
-    // Each round: append 49, flush (fails). After each flush events = previous + 49.
-    //
-    // Round 1: snap=49 fail → events=49
-    // Round 2: snap=49+49=98 fail → events=98
-    // Round 3: snap=98+49=147 fail → events=147
-    // Round 4: snap=147+49=196 fail → events=196
-    // Round 5: snap=196+49=245 fail → combined=245 > 200 → drop 45, log "dropped 45"
-
     let cap = EventBuffer.maxReenqueueCap
-    let batchSize = 49 // stay below auto-flush threshold of 50
-    let rounds = 5
-    let expectedTotal = batchSize * rounds // 245
-    let expectedDrop = expectedTotal - cap // 45
+    let expectedTotal = cap + 45
+    let expectedDrop = expectedTotal - cap
 
     let logMessages = LockIsolated<[String]>([])
 
     let buffer = EventBuffer(
       flushHandler: { _ in throw URLError(.notConnectedToInternet) },
-      logHandler: { msg in logMessages.withValue { $0.append(msg) } }
+      logHandler: { msg in logMessages.withValue { $0.append(msg) } },
+      maxBatchSize: .max
     )
 
-    for _ in 0 ..< rounds {
-      for _ in 0 ..< batchSize {
-        await buffer.append(makeEvent())
-      }
-      await buffer.flush()
+    for _ in 0 ..< expectedTotal {
+      await buffer.append(makeEvent())
     }
+    await buffer.flush()
 
     let dropLog = logMessages.value.first { $0.contains("dropped") }
-    #expect(dropLog != nil, "Expected a drop log after \(rounds) rounds; got: \(logMessages.value)")
+    #expect(dropLog != nil, "Expected a drop log; got: \(logMessages.value)")
     #expect(
       dropLog?.contains("\(expectedDrop)") == true,
       "Expected drop count of \(expectedDrop); got: \(dropLog ?? "nil")"

--- a/OfflineMediaDownloaderTests/LiveActivityCoalescingTests.swift
+++ b/OfflineMediaDownloaderTests/LiveActivityCoalescingTests.swift
@@ -300,7 +300,14 @@ struct LiveActivityCoalescingTests {
       await Task.yield()
     }
 
-    // Resume the second call.
+    // The updater increments the call count just before it stores its continuation.
+    // On a fast CI runner, observing callCount == 2 does not yet guarantee that the
+    // continuation is available to resume.
+    while inFlightContinuation.value == nil {
+      await Task.yield()
+    }
+
+    // Resume the second call once its continuation has been captured.
     inFlightContinuation.value?.resume()
 
     await firstUpdate

--- a/Packages/OMDFeatures/Sources/AnalyticsClient/EventBuffer.swift
+++ b/Packages/OMDFeatures/Sources/AnalyticsClient/EventBuffer.swift
@@ -5,8 +5,9 @@ public actor EventBuffer {
   private var flushTask: Task<Void, Never>?
   private let flushHandler: @Sendable (Data) async throws -> Void
   private let logHandler: @Sendable (String) -> Void
+  private let maxBatchSize: Int
 
-  private static let maxBatchSize = 50
+  private static let defaultMaxBatchSize = 50
   private static let flushInterval: TimeInterval = 60
   /// Internal so tests can use it when building controlled failure sequences.
   static let maxRetries = 3
@@ -19,8 +20,23 @@ public actor EventBuffer {
     flushHandler: @escaping @Sendable (Data) async throws -> Void,
     logHandler: @escaping @Sendable (String) -> Void = { _ in }
   ) {
+    self.init(
+      flushHandler: flushHandler,
+      logHandler: logHandler,
+      maxBatchSize: Self.defaultMaxBatchSize
+    )
+  }
+
+  /// Internal seam for deterministic tests of buffering behavior that would
+  /// otherwise trigger automatic background flushes at the production limit.
+  init(
+    flushHandler: @escaping @Sendable (Data) async throws -> Void,
+    logHandler: @escaping @Sendable (String) -> Void,
+    maxBatchSize: Int
+  ) {
     self.flushHandler = flushHandler
     self.logHandler = logHandler
+    self.maxBatchSize = maxBatchSize
   }
 
   public func start() {
@@ -35,7 +51,7 @@ public actor EventBuffer {
 
   public func append(_ event: ClientEvent) {
     events.append(event)
-    if events.count >= Self.maxBatchSize {
+    if events.count >= maxBatchSize {
       Task { await flush() }
     }
   }

--- a/Scripts/setup-hooks.sh
+++ b/Scripts/setup-hooks.sh
@@ -14,10 +14,12 @@ git config core.hooksPath .githooks
 
 # Make hooks executable
 chmod +x "$PROJECT_ROOT/.githooks/commit-msg"
+chmod +x "$PROJECT_ROOT/.githooks/post-checkout"
 chmod +x "$PROJECT_ROOT/.githooks/pre-push"
 
 echo "✅ Git hooks configured successfully!"
 echo ""
 echo "Hooks installed:"
 echo "  - commit-msg: Blocks AI attribution in commit messages"
+echo "  - post-checkout: Provisions fresh linked worktrees"
 echo "  - pre-push: Blocks direct main pushes, verifies Xcode build"

--- a/Scripts/worktree-setup.sh
+++ b/Scripts/worktree-setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Seed only gitignored, per-machine configuration. This script is idempotent:
+# existing worktree-local files win, and provisioning failures are non-fatal.
+set -u
+
+worktree="$(git rev-parse --show-toplevel)"
+main="$(dirname "$(git rev-parse --git-common-dir)")"
+[ "$worktree" = "$main" ] && exit 0
+
+log() { printf 'worktree-setup: %s\n' "$1"; }
+
+for rel in .claude/settings.local.json Development.xcconfig; do
+  src="$main/$rel"
+  dst="$worktree/$rel"
+  if [ -e "$src" ] && [ ! -e "$dst" ]; then
+    mkdir -p "$(dirname "$dst")"
+    cp -R "$src" "$dst" && log "seeded $rel" || log "WARN: failed to seed $rel"
+  fi
+done
+
+if [ "${WORKTREE_SKIP_INSTALL:-0}" != "1" ]; then
+  (cd "$worktree/APITypes" && swift package resolve) >/dev/null 2>&1 \
+    && log 'resolved APITypes' \
+    || log 'WARN: APITypes resolution failed — run swift package resolve manually'
+fi
+
+log done

--- a/Scripts/worktree-setup.sh
+++ b/Scripts/worktree-setup.sh
@@ -14,14 +14,20 @@ for rel in .claude/settings.local.json Development.xcconfig; do
   dst="$worktree/$rel"
   if [ -e "$src" ] && [ ! -e "$dst" ]; then
     mkdir -p "$(dirname "$dst")"
-    cp -R "$src" "$dst" && log "seeded $rel" || log "WARN: failed to seed $rel"
+    if cp -R "$src" "$dst"; then
+      log "seeded $rel"
+    else
+      log "WARN: failed to seed $rel"
+    fi
   fi
 done
 
 if [ "${WORKTREE_SKIP_INSTALL:-0}" != "1" ]; then
-  (cd "$worktree/APITypes" && swift package resolve) >/dev/null 2>&1 \
-    && log 'resolved APITypes' \
-    || log 'WARN: APITypes resolution failed — run swift package resolve manually'
+  if (cd "$worktree/APITypes" && swift package resolve) >/dev/null 2>&1; then
+    log 'resolved APITypes'
+  else
+    log 'WARN: APITypes resolution failed — run swift package resolve manually'
+  fi
 fi
 
-log done
+log 'done'


### PR DESCRIPTION
## Summary

Two independent pieces landed together:

1. **Worktree provisioning** — rolls Atlas decision **0004** (resilient worktree provisioning — estate standard) into `ios-OfflineMediaDownloader`.
2. **Test-determinism fixes** — hardens two flaky async tests surfaced while validating the worktree setup on a fast runner.

## Worktree provisioning

- **`.githooks/post-checkout`** + **`Scripts/setup-hooks.sh`** — the git-native trigger and its installer (`core.hooksPath = .githooks`).
- **`Scripts/worktree-setup.sh`** — seeds the gitignored-but-required local files from the main checkout **only if missing** (never clobbers), using `git rev-parse` for path discovery: `.claude/settings.local.json` (the DevTools MCP token) and `Development.xcconfig`. Then `swift package resolve` for `APITypes`. Non-fatal and idempotent; escape hatch `WORKTREE_SKIP_INSTALL=1`.

## Test-determinism fixes

- **`EventBuffer` cap test** — the old test relied on a fragile interaction with the fixed auto-flush threshold (5 rounds of 49 appends) to force a drop. Made `maxBatchSize` an injectable init parameter (default unchanged at 50) so the test sets it to `.max`, appends `cap + 45` events directly, and flushes once — removing the timing dependency. Production behavior is unchanged (backward-compatible default).
- **Live-activity coalescing test** — observing `callCount == 2` did not guarantee the second call's continuation had been stored yet on a fast runner. Added a `while inFlightContinuation.value == nil { await Task.yield() }` precondition wait before resuming, so the test synchronizes on the actual state instead of assuming it.

## Verification

- Fresh linked-worktree smoke test: local config seeds and `APITypes` resolves.
- Full test suite green, including the two hardened tests run repeatedly.
